### PR TITLE
Add configurable 2025 tax rules

### DIFF
--- a/internal/go.mod
+++ b/internal/go.mod
@@ -1,0 +1,3 @@
+module baristeuer/internal
+
+go 1.20

--- a/internal/taxrules/README.md
+++ b/internal/taxrules/README.md
@@ -1,0 +1,24 @@
+# Tax Rules Module
+
+This package provides tax calculations for club projects. Rules for each year
+are stored in separate JSON files so that new years can be added without code
+changes.
+
+## Configuration
+
+For 2025 the file `rules2025.json` defines the following fields:
+
+- `allowance`  – basic tax-free amount
+- `rate`       – tax rate applied above the threshold
+- `threshold`  – income level after which tax applies
+
+## Usage Example
+
+```go
+import "baristeuer/internal/taxrules"
+
+p := taxrules.Project{Revenue: 10000, Expenses: 2000}
+tax := taxrules.CalculateTax(p)
+```
+
+`tax` will contain the amount due according to the 2025 rules.

--- a/internal/taxrules/rules2025.go
+++ b/internal/taxrules/rules2025.go
@@ -1,0 +1,52 @@
+package taxrules
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+)
+
+type Rules struct {
+	Allowance float64 `json:"allowance"`
+	Rate      float64 `json:"rate"`
+	Threshold float64 `json:"threshold"`
+}
+
+var rules2025 Rules
+
+func init() {
+	if err := loadRules2025(); err != nil {
+		panic(err)
+	}
+}
+
+func loadRules2025() error {
+	_, file, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(file)
+	path := filepath.Join(dir, "rules2025.json")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return fmt.Errorf("read config: %w", err)
+	}
+	if err := json.Unmarshal(data, &rules2025); err != nil {
+		return fmt.Errorf("parse config: %w", err)
+	}
+	return nil
+}
+
+// Project represents a simple club project with revenue and expenses.
+type Project struct {
+	Revenue  float64
+	Expenses float64
+}
+
+// CalculateTax computes the tax due for a project based on the 2025 rules.
+func CalculateTax(p Project) float64 {
+	taxable := p.Revenue - p.Expenses - rules2025.Allowance
+	if taxable <= rules2025.Threshold {
+		return 0
+	}
+	return (taxable - rules2025.Threshold) * rules2025.Rate
+}

--- a/internal/taxrules/rules2025.json
+++ b/internal/taxrules/rules2025.json
@@ -1,0 +1,5 @@
+{
+  "allowance": 1000.0,
+  "rate": 0.20,
+  "threshold": 5000.0
+}


### PR DESCRIPTION
## Summary
- initialize `internal` Go module
- add configurable 2025 tax rules and calculation helpers
- document how to use the tax rules

## Testing
- `go build ./...` in `internal`
- `go build ./...` in `cmd`

------
https://chatgpt.com/codex/tasks/task_e_68643f9f91a08333ad24c896b501cb21