### PR TITLE
Add SQLite data storage with CRUD tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Baristeuer is a proof-of-concept desktop application for managing **Vereinssteue
 - **Go** 1.20 or later
 - **Node.js** 18 or later
 - **Wails** (install via `go install github.com/wailsapp/wails/v2/cmd/wails@latest`)
+- **SQLite** development headers (required by `github.com/mattn/go-sqlite3`)
 
 Ensure these tools are available in your `PATH` before building the project.
 

--- a/cmd/go.mod
+++ b/cmd/go.mod
@@ -1,3 +1,0 @@
-module baristeuer
-
-go 1.20

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,5 @@
+module baristeuer
+
+go 1.23.8
+
+require github.com/mattn/go-sqlite3 v1.14.28

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+github.com/mattn/go-sqlite3 v1.14.28 h1:ThEiQrnbtumT+QMknw63Befp/ce/nUPgBPMlRFEum7A=
+github.com/mattn/go-sqlite3 v1.14.28/go.mod h1:Uh1q+B4BYcTPb+yiD3kU8Ct7aC0hY9fxUwlHK0RXw+Y=

--- a/internal/data/models.go
+++ b/internal/data/models.go
@@ -1,0 +1,29 @@
+package data
+
+import "time"
+
+// Project represents a club project or activity.
+type Project struct {
+	ID          int64     `json:"id"`
+	Name        string    `json:"name"`
+	Description string    `json:"description"`
+	CreatedAt   time.Time `json:"created_at"`
+}
+
+// Income represents money received for a project.
+type Income struct {
+	ID          int64     `json:"id"`
+	ProjectID   int64     `json:"project_id"`
+	Amount      float64   `json:"amount"`
+	Description string    `json:"description"`
+	Date        time.Time `json:"date"`
+}
+
+// Expense represents money spent for a project.
+type Expense struct {
+	ID          int64     `json:"id"`
+	ProjectID   int64     `json:"project_id"`
+	Amount      float64   `json:"amount"`
+	Description string    `json:"description"`
+	Date        time.Time `json:"date"`
+}

--- a/internal/data/store.go
+++ b/internal/data/store.go
@@ -1,0 +1,192 @@
+package data
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"time"
+)
+
+// Store wraps a sql.DB instance.
+type Store struct {
+	DB *sql.DB
+}
+
+// NewStore returns a new Store.
+func NewStore(db *sql.DB) *Store {
+	return &Store{DB: db}
+}
+
+// Init creates database tables if they do not exist.
+func (s *Store) Init(ctx context.Context) error {
+	queries := []string{
+		`CREATE TABLE IF NOT EXISTS projects (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            name TEXT,
+            description TEXT,
+            created_at DATETIME
+        )`,
+		`CREATE TABLE IF NOT EXISTS incomes (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            project_id INTEGER,
+            amount REAL,
+            description TEXT,
+            date DATETIME,
+            FOREIGN KEY(project_id) REFERENCES projects(id)
+        )`,
+		`CREATE TABLE IF NOT EXISTS expenses (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            project_id INTEGER,
+            amount REAL,
+            description TEXT,
+            date DATETIME,
+            FOREIGN KEY(project_id) REFERENCES projects(id)
+        )`,
+	}
+
+	for _, q := range queries {
+		if _, err := s.DB.ExecContext(ctx, q); err != nil {
+			return fmt.Errorf("init db: %w", err)
+		}
+	}
+	return nil
+}
+
+// --- Project CRUD ---
+
+func (s *Store) CreateProject(ctx context.Context, p *Project) error {
+	p.CreatedAt = time.Now()
+	res, err := s.DB.ExecContext(ctx, `INSERT INTO projects(name, description, created_at) VALUES(?,?,?)`, p.Name, p.Description, p.CreatedAt)
+	if err != nil {
+		return err
+	}
+	p.ID, err = res.LastInsertId()
+	return err
+}
+
+func (s *Store) GetProject(ctx context.Context, id int64) (Project, error) {
+	var p Project
+	row := s.DB.QueryRowContext(ctx, `SELECT id, name, description, created_at FROM projects WHERE id = ?`, id)
+	err := row.Scan(&p.ID, &p.Name, &p.Description, &p.CreatedAt)
+	return p, err
+}
+
+func (s *Store) UpdateProject(ctx context.Context, p *Project) error {
+	_, err := s.DB.ExecContext(ctx, `UPDATE projects SET name=?, description=? WHERE id=?`, p.Name, p.Description, p.ID)
+	return err
+}
+
+func (s *Store) DeleteProject(ctx context.Context, id int64) error {
+	_, err := s.DB.ExecContext(ctx, `DELETE FROM projects WHERE id=?`, id)
+	return err
+}
+
+func (s *Store) ListProjects(ctx context.Context) ([]Project, error) {
+	rows, err := s.DB.QueryContext(ctx, `SELECT id, name, description, created_at FROM projects`)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var projects []Project
+	for rows.Next() {
+		var p Project
+		if err := rows.Scan(&p.ID, &p.Name, &p.Description, &p.CreatedAt); err != nil {
+			return nil, err
+		}
+		projects = append(projects, p)
+	}
+	return projects, rows.Err()
+}
+
+// --- Income CRUD ---
+
+func (s *Store) CreateIncome(ctx context.Context, in *Income) error {
+	res, err := s.DB.ExecContext(ctx, `INSERT INTO incomes(project_id, amount, description, date) VALUES(?,?,?,?)`, in.ProjectID, in.Amount, in.Description, in.Date)
+	if err != nil {
+		return err
+	}
+	in.ID, err = res.LastInsertId()
+	return err
+}
+
+func (s *Store) GetIncome(ctx context.Context, id int64) (Income, error) {
+	var in Income
+	row := s.DB.QueryRowContext(ctx, `SELECT id, project_id, amount, description, date FROM incomes WHERE id=?`, id)
+	err := row.Scan(&in.ID, &in.ProjectID, &in.Amount, &in.Description, &in.Date)
+	return in, err
+}
+
+func (s *Store) UpdateIncome(ctx context.Context, in *Income) error {
+	_, err := s.DB.ExecContext(ctx, `UPDATE incomes SET project_id=?, amount=?, description=?, date=? WHERE id=?`, in.ProjectID, in.Amount, in.Description, in.Date, in.ID)
+	return err
+}
+
+func (s *Store) DeleteIncome(ctx context.Context, id int64) error {
+	_, err := s.DB.ExecContext(ctx, `DELETE FROM incomes WHERE id=?`, id)
+	return err
+}
+
+func (s *Store) ListIncomesByProject(ctx context.Context, projectID int64) ([]Income, error) {
+	rows, err := s.DB.QueryContext(ctx, `SELECT id, project_id, amount, description, date FROM incomes WHERE project_id=?`, projectID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var items []Income
+	for rows.Next() {
+		var in Income
+		if err := rows.Scan(&in.ID, &in.ProjectID, &in.Amount, &in.Description, &in.Date); err != nil {
+			return nil, err
+		}
+		items = append(items, in)
+	}
+	return items, rows.Err()
+}
+
+// --- Expense CRUD ---
+
+func (s *Store) CreateExpense(ctx context.Context, ex *Expense) error {
+	res, err := s.DB.ExecContext(ctx, `INSERT INTO expenses(project_id, amount, description, date) VALUES(?,?,?,?)`, ex.ProjectID, ex.Amount, ex.Description, ex.Date)
+	if err != nil {
+		return err
+	}
+	ex.ID, err = res.LastInsertId()
+	return err
+}
+
+func (s *Store) GetExpense(ctx context.Context, id int64) (Expense, error) {
+	var ex Expense
+	row := s.DB.QueryRowContext(ctx, `SELECT id, project_id, amount, description, date FROM expenses WHERE id=?`, id)
+	err := row.Scan(&ex.ID, &ex.ProjectID, &ex.Amount, &ex.Description, &ex.Date)
+	return ex, err
+}
+
+func (s *Store) UpdateExpense(ctx context.Context, ex *Expense) error {
+	_, err := s.DB.ExecContext(ctx, `UPDATE expenses SET project_id=?, amount=?, description=?, date=? WHERE id=?`, ex.ProjectID, ex.Amount, ex.Description, ex.Date, ex.ID)
+	return err
+}
+
+func (s *Store) DeleteExpense(ctx context.Context, id int64) error {
+	_, err := s.DB.ExecContext(ctx, `DELETE FROM expenses WHERE id=?`, id)
+	return err
+}
+
+func (s *Store) ListExpensesByProject(ctx context.Context, projectID int64) ([]Expense, error) {
+	rows, err := s.DB.QueryContext(ctx, `SELECT id, project_id, amount, description, date FROM expenses WHERE project_id=?`, projectID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var items []Expense
+	for rows.Next() {
+		var ex Expense
+		if err := rows.Scan(&ex.ID, &ex.ProjectID, &ex.Amount, &ex.Description, &ex.Date); err != nil {
+			return nil, err
+		}
+		items = append(items, ex)
+	}
+	return items, rows.Err()
+}

--- a/internal/data/store_test.go
+++ b/internal/data/store_test.go
@@ -1,0 +1,86 @@
+package data
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+	"time"
+
+	_ "github.com/mattn/go-sqlite3"
+)
+
+func newTestStore(t *testing.T) *Store {
+	t.Helper()
+	db, err := sql.Open("sqlite3", ":memory:")
+	if err != nil {
+		t.Fatal(err)
+	}
+	s := NewStore(db)
+	if err := s.Init(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	return s
+}
+
+func TestProjectCRUD(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+
+	p := &Project{Name: "Proj", Description: "desc"}
+	if err := s.CreateProject(ctx, p); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	got, err := s.GetProject(ctx, p.ID)
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if got.Name != p.Name {
+		t.Fatalf("want name %q got %q", p.Name, got.Name)
+	}
+
+	p.Name = "NewName"
+	if err := s.UpdateProject(ctx, p); err != nil {
+		t.Fatalf("update: %v", err)
+	}
+	got, _ = s.GetProject(ctx, p.ID)
+	if got.Name != "NewName" {
+		t.Fatalf("update failed")
+	}
+
+	if err := s.DeleteProject(ctx, p.ID); err != nil {
+		t.Fatalf("delete: %v", err)
+	}
+	if _, err := s.GetProject(ctx, p.ID); err == nil {
+		t.Fatalf("expected error after delete")
+	}
+}
+
+func TestIncomeExpenseCRUD(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+
+	p := &Project{Name: "Proj"}
+	if err := s.CreateProject(ctx, p); err != nil {
+		t.Fatal(err)
+	}
+
+	in := &Income{ProjectID: p.ID, Amount: 10, Description: "donation", Date: time.Now()}
+	if err := s.CreateIncome(ctx, in); err != nil {
+		t.Fatalf("create income: %v", err)
+	}
+
+	ex := &Expense{ProjectID: p.ID, Amount: 5, Description: "cost", Date: time.Now()}
+	if err := s.CreateExpense(ctx, ex); err != nil {
+		t.Fatalf("create expense: %v", err)
+	}
+
+	ins, err := s.ListIncomesByProject(ctx, p.ID)
+	if err != nil || len(ins) != 1 {
+		t.Fatalf("list incomes: %v len=%d", err, len(ins))
+	}
+
+	exs, err := s.ListExpensesByProject(ctx, p.ID)
+	if err != nil || len(exs) != 1 {
+		t.Fatalf("list expenses: %v len=%d", err, len(exs))
+	}
+}


### PR DESCRIPTION
## Summary
- define `Project`, `Income`, `Expense` models
- implement SQLite-backed `Store` with CRUD functionality
- add unit tests verifying CRUD operations
- initialize Go module and add sqlite3 dependency
- document sqlite prerequisite

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68643f9ddb8c8333b8aa75a2e119e6e8