### PR TITLE
Add PDF report generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,4 +39,11 @@ Integration with Wails will later allow packaging everything as a desktop app.
 - Package the application via Wails for Windows, macOS and Linux
 - Add PDF export and optional cloud sync
 
+## Generating Reports
+
+The `internal/pdf` module contains a `GenerateReport(projectID)` function
+that fetches project data and creates a PDF using `gofpdf`. Generated
+files are stored under `data/reports/<projectID>/report.pdf`. A placeholder
+button in the React UI invokes this function through a Wails binding.
+
 Contributions and feedback are welcome!

--- a/cmd/go.mod
+++ b/cmd/go.mod
@@ -1,3 +1,14 @@
 module baristeuer
 
 go 1.20
+
+require baristeuer/internal/pdf v0.0.0
+
+require (
+	baristeuer/internal/data v0.0.0 // indirect
+	github.com/jung-kurt/gofpdf v1.16.2 // indirect
+)
+
+replace baristeuer/internal/pdf => ../internal/pdf
+
+replace baristeuer/internal/data => ../internal/data

--- a/cmd/go.sum
+++ b/cmd/go.sum
@@ -1,0 +1,12 @@
+github.com/boombuler/barcode v1.0.0/go.mod h1:paBWMcWSl3LHKBqUq+rly7CNSldXjb2rDl3JlRe0mD8=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/jung-kurt/gofpdf v1.0.0/go.mod h1:7Id9E/uU8ce6rXgefFLlgrJj/GYY22cpxn+r32jIOes=
+github.com/jung-kurt/gofpdf v1.16.2 h1:jgbatWHfRlPYiK85qgevsZTHviWXKwB1TTiKdz5PtRc=
+github.com/jung-kurt/gofpdf v1.16.2/go.mod h1:1hl7y57EsiPAkLbOwzpzqgx1A30nQCk/YmFV8S2vmK0=
+github.com/phpdave11/gofpdi v1.0.7/go.mod h1:vBmVV0Do6hSBHC8uKUQ71JGW+ZGQq74llk/7bXwjDoI=
+github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/ruudk/golang-pdf417 v0.0.0-20181029194003-1af4ab5afa58/go.mod h1:6lfFZQK844Gfx8o5WFuvpxWRwnSoipWe/p622j1v06w=
+github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
+golang.org/x/image v0.0.0-20190910094157-69e4b8554b2a/go.mod h1:FeLwcggjj3mMvU+oOTbSwawSJRM1uh48EjtB4UJZlP0=
+golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -1,7 +1,17 @@
 package main
 
-import "fmt"
+import (
+	"fmt"
+
+	"baristeuer/internal/pdf"
+)
 
 func main() {
 	fmt.Println("Baristeuer CLI")
+
+	if path, err := pdf.GenerateReport("demo"); err != nil {
+		fmt.Println("error generating report:", err)
+	} else {
+		fmt.Println("report generated at", path)
+	}
 }

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -1,0 +1,11 @@
+package app
+
+import "baristeuer/internal/pdf"
+
+// App is a Wails binding placeholder.
+type App struct{}
+
+// GenerateReport generates a PDF report for the given project.
+func (a *App) GenerateReport(projectID string) (string, error) {
+	return pdf.GenerateReport(projectID)
+}

--- a/internal/data/go.mod
+++ b/internal/data/go.mod
@@ -1,0 +1,3 @@
+module baristeuer/internal/data
+
+go 1.20

--- a/internal/data/project.go
+++ b/internal/data/project.go
@@ -1,0 +1,17 @@
+package data
+
+// ProjectData represents placeholder project information.
+type ProjectData struct {
+	ID   string
+	Name string
+	Info string
+}
+
+// GetProjectData returns dummy data for a project.
+func GetProjectData(projectID string) ProjectData {
+	return ProjectData{
+		ID:   projectID,
+		Name: "Example Project" + " " + projectID,
+		Info: "This is placeholder project information used for PDF generation.",
+	}
+}

--- a/internal/pdf/go.mod
+++ b/internal/pdf/go.mod
@@ -1,0 +1,10 @@
+module baristeuer/internal/pdf
+
+go 1.20
+
+require (
+	baristeuer/internal/data v0.0.0
+	github.com/jung-kurt/gofpdf v1.16.2
+)
+
+replace baristeuer/internal/data => ../data

--- a/internal/pdf/go.sum
+++ b/internal/pdf/go.sum
@@ -1,0 +1,12 @@
+github.com/boombuler/barcode v1.0.0/go.mod h1:paBWMcWSl3LHKBqUq+rly7CNSldXjb2rDl3JlRe0mD8=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/jung-kurt/gofpdf v1.0.0/go.mod h1:7Id9E/uU8ce6rXgefFLlgrJj/GYY22cpxn+r32jIOes=
+github.com/jung-kurt/gofpdf v1.16.2 h1:jgbatWHfRlPYiK85qgevsZTHviWXKwB1TTiKdz5PtRc=
+github.com/jung-kurt/gofpdf v1.16.2/go.mod h1:1hl7y57EsiPAkLbOwzpzqgx1A30nQCk/YmFV8S2vmK0=
+github.com/phpdave11/gofpdi v1.0.7/go.mod h1:vBmVV0Do6hSBHC8uKUQ71JGW+ZGQq74llk/7bXwjDoI=
+github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/ruudk/golang-pdf417 v0.0.0-20181029194003-1af4ab5afa58/go.mod h1:6lfFZQK844Gfx8o5WFuvpxWRwnSoipWe/p622j1v06w=
+github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
+golang.org/x/image v0.0.0-20190910094157-69e4b8554b2a/go.mod h1:FeLwcggjj3mMvU+oOTbSwawSJRM1uh48EjtB4UJZlP0=
+golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/internal/pdf/report.go
+++ b/internal/pdf/report.go
@@ -1,0 +1,36 @@
+package pdf
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"baristeuer/internal/data"
+	"github.com/jung-kurt/gofpdf"
+)
+
+// GenerateReport fetches project data and creates a PDF report.
+func GenerateReport(projectID string) (string, error) {
+	// Fetch data (placeholder implementation)
+	project := data.GetProjectData(projectID)
+
+	dir := filepath.Join("data", "reports", projectID)
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		return "", err
+	}
+
+	file := filepath.Join(dir, "report.pdf")
+
+	pdf := gofpdf.New("P", "mm", "A4", "")
+	pdf.AddPage()
+	pdf.SetFont("Arial", "B", 16)
+	pdf.Cell(40, 10, fmt.Sprintf("Report for %s", project.Name))
+	pdf.Ln(12)
+	pdf.SetFont("Arial", "", 12)
+	pdf.MultiCell(0, 10, project.Info, "", "", false)
+
+	if err := pdf.OutputFileAndClose(file); err != nil {
+		return "", err
+	}
+	return file, nil
+}

--- a/internal/ui/src/index.js
+++ b/internal/ui/src/index.js
@@ -1,8 +1,23 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 
+function generateReport() {
+  if (window.backend && window.backend.GenerateReport) {
+    window.backend.GenerateReport('demo')
+      .then(() => console.log('Report generated'))
+      .catch((err) => console.error(err));
+  } else {
+    console.log('Backend not available');
+  }
+}
+
 function App() {
-  return <div>Hello from Baristeuer UI</div>;
+  return (
+    <div>
+      Hello from Baristeuer UI
+      <button onClick={generateReport}>Generate Report</button>
+    </div>
+  );
 }
 
 const root = ReactDOM.createRoot(document.getElementById('root'));


### PR DESCRIPTION
## Summary
- scaffold internal `pdf` module with `gofpdf`
- add placeholder data module
- expose `GenerateReport` via Wails `App` struct
- call report generation in CLI
- add React button to trigger report generation
- document report feature in README

## Testing
- `go build ./...`

------
https://chatgpt.com/codex/tasks/task_e_68643fa05b648333a440034db93f4e77