### PR TITLE
Add simple PDF report generator

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -1,15 +1,18 @@
 package main
 
 import (
+	"baristeuer/internal/pdf"
 	"github.com/wailsapp/wails/v2"
 	"github.com/wailsapp/wails/v2/pkg/options"
 	"github.com/wailsapp/wails/v2/pkg/options/assetserver"
 )
 
 func main() {
+	generator := pdf.NewGenerator("")
 	err := wails.Run(&options.App{
 		Title:       "Baristeuer",
 		AssetServer: &assetserver.Options{},
+		Bind:        []interface{}{generator},
 	})
 	if err != nil {
 		println("Error:", err.Error())

--- a/go.work
+++ b/go.work
@@ -1,0 +1,7 @@
+go 1.23.8
+
+use (
+	./cmd
+	./internal
+	./internal/pdf
+)

--- a/internal/pdf/go.mod
+++ b/internal/pdf/go.mod
@@ -1,0 +1,5 @@
+module baristeuer/internal/pdf
+
+go 1.20
+
+require github.com/jung-kurt/gofpdf v1.0.0

--- a/internal/pdf/go.sum
+++ b/internal/pdf/go.sum
@@ -1,0 +1,2 @@
+github.com/jung-kurt/gofpdf v1.0.0 h1:EroSdlP9BOoL5ssLYf3uLJXhCQMMM2fFxCJDKA3RhnA=
+github.com/jung-kurt/gofpdf v1.0.0/go.mod h1:7Id9E/uU8ce6rXgefFLlgrJj/GYY22cpxn+r32jIOes=

--- a/internal/pdf/pdf.go
+++ b/internal/pdf/pdf.go
@@ -1,0 +1,54 @@
+package pdf
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/jung-kurt/gofpdf"
+
+	taxrules "baristeuer/internal/taxrules"
+)
+
+// Generator handles PDF creation.
+type Generator struct {
+	BasePath string
+}
+
+// NewGenerator returns a new Generator storing reports under basePath.
+func NewGenerator(basePath string) *Generator {
+	if basePath == "" {
+		basePath = filepath.Join(".", "internal", "data")
+	}
+	return &Generator{BasePath: basePath}
+}
+
+// GenerateReport fetches project data and creates a PDF report.
+func (g *Generator) GenerateReport(projectID string) (string, error) {
+	// placeholder project data
+	p := taxrules.Project{Revenue: 1000, Expenses: 500}
+
+	dir := filepath.Join(g.BasePath, projectID)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return "", fmt.Errorf("create project dir: %w", err)
+	}
+	file := filepath.Join(dir, "report.pdf")
+
+	pdf := gofpdf.New("P", "mm", "A4", "")
+	pdf.AddPage()
+	pdf.SetFont("Arial", "B", 16)
+	pdf.Cell(40, 10, fmt.Sprintf("Report for project %s", projectID))
+	pdf.Ln(12)
+	pdf.SetFont("Arial", "", 12)
+	pdf.Cell(40, 10, fmt.Sprintf("Revenue: %.2f", p.Revenue))
+	pdf.Ln(8)
+	pdf.Cell(40, 10, fmt.Sprintf("Expenses: %.2f", p.Expenses))
+	pdf.Ln(8)
+	tax := taxrules.CalculateTax(p)
+	pdf.Cell(40, 10, fmt.Sprintf("Tax: %.2f", tax))
+
+	if err := pdf.OutputFileAndClose(file); err != nil {
+		return "", fmt.Errorf("write pdf: %w", err)
+	}
+	return file, nil
+}

--- a/internal/ui/src/App.jsx
+++ b/internal/ui/src/App.jsx
@@ -1,5 +1,6 @@
 import { useMemo, useState } from 'react'
 import { createTheme, ThemeProvider, CssBaseline, Button } from '@mui/material'
+import { GenerateReport } from './wailsjs/go/pdf/Generator'
 
 function App() {
   const [mode, setMode] = useState('light')
@@ -9,12 +10,24 @@ function App() {
     setMode(prev => (prev === 'light' ? 'dark' : 'light'))
   }
 
+  const handleReport = async () => {
+    try {
+      const path = await GenerateReport('demo')
+      console.log('PDF saved at', path)
+    } catch (err) {
+      console.error(err)
+    }
+  }
+
   return (
     <ThemeProvider theme={theme}>
       <CssBaseline />
       <div style={{ padding: '1rem' }}>
         <Button variant="contained" onClick={toggleMode}>
           Switch to {mode === 'light' ? 'dark' : 'light'} mode
+        </Button>
+        <Button variant="outlined" onClick={handleReport} style={{ marginLeft: '1rem' }}>
+          Generate PDF Report
         </Button>
       </div>
     </ThemeProvider>

--- a/internal/ui/src/wailsjs/go/pdf/Generator.js
+++ b/internal/ui/src/wailsjs/go/pdf/Generator.js
@@ -1,0 +1,3 @@
+export function GenerateReport(projectID) {
+  return window.go.pdf.Generator.GenerateReport(projectID);
+}


### PR DESCRIPTION
## Summary
- introduce a PDF generation submodule
- expose `GenerateReport` via Wails bindings
- wire frontend button to trigger report generation
- create basic wails workspace file

## Testing
- `go vet ./cmd/... ./internal/... ./internal/pdf/...`
- `go test ./cmd/... ./internal/... ./internal/pdf/...`
- `npm install` and `npm run build` in `internal/ui`


------
https://chatgpt.com/codex/tasks/task_e_686518aafad88333bf8add53fed5eaa7