### PR TITLE
Add tests for income and expense helpers

### DIFF
--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -46,6 +46,15 @@ func (ds *DataService) ListIncomes(projectID int64) ([]data.Income, error) {
 	return incomes, nil
 }
 
+// AddIncome adds a new income to the given project.
+func (ds *DataService) AddIncome(projectID int64, source string, amount float64) (*data.Income, error) {
+	i := &data.Income{ProjectID: projectID, Source: source, Amount: amount}
+	if err := ds.store.CreateIncome(i); err != nil {
+		return nil, err
+	}
+	return i, nil
+}
+
 // AddExpense adds a new expense to the given project.
 func (ds *DataService) AddExpense(projectID int64, category string, amount float64) (*data.Expense, error) {
 	e := &data.Expense{ProjectID: projectID, Category: category, Amount: amount}
@@ -53,6 +62,25 @@ func (ds *DataService) AddExpense(projectID int64, category string, amount float
 		return nil, err
 	}
 	return e, nil
+}
+
+// ListExpenses returns all expenses for the given project.
+func (ds *DataService) ListExpenses(projectID int64) ([]data.Expense, error) {
+	rows, err := ds.store.DB.Query(`SELECT id, project_id, category, amount FROM expenses WHERE project_id=?`, projectID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var expenses []data.Expense
+	for rows.Next() {
+		var e data.Expense
+		if err := rows.Scan(&e.ID, &e.ProjectID, &e.Category, &e.Amount); err != nil {
+			return nil, err
+		}
+		expenses = append(expenses, e)
+	}
+	return expenses, nil
 }
 
 // Close closes the underlying datastore.

--- a/internal/service/service_test.go
+++ b/internal/service/service_test.go
@@ -1,0 +1,60 @@
+package service
+
+import "testing"
+
+func TestDataService_AddIncome(t *testing.T) {
+	ds, err := NewDataService(":memory:")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ds.Close()
+
+	proj, err := ds.CreateProject("Income Project")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	inc, err := ds.AddIncome(proj.ID, "donation", 15)
+	if err != nil {
+		t.Fatalf("AddIncome returned error: %v", err)
+	}
+	if inc.ID == 0 {
+		t.Fatalf("expected income ID to be set")
+	}
+
+	list, err := ds.ListIncomes(proj.ID)
+	if err != nil {
+		t.Fatalf("ListIncomes returned error: %v", err)
+	}
+	if len(list) != 1 || list[0].Amount != 15 {
+		t.Fatalf("unexpected incomes: %+v", list)
+	}
+}
+
+func TestDataService_ListExpenses(t *testing.T) {
+	ds, err := NewDataService(":memory:")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ds.Close()
+
+	proj, err := ds.CreateProject("Expense Project")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := ds.AddExpense(proj.ID, "supplies", 5); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := ds.AddExpense(proj.ID, "food", 7); err != nil {
+		t.Fatal(err)
+	}
+
+	expenses, err := ds.ListExpenses(proj.ID)
+	if err != nil {
+		t.Fatalf("ListExpenses returned error: %v", err)
+	}
+	if len(expenses) != 2 {
+		t.Fatalf("expected 2 expenses, got %d", len(expenses))
+	}
+}

--- a/internal/ui/src/wailsjs/go/service/DataService.js
+++ b/internal/ui/src/wailsjs/go/service/DataService.js
@@ -6,6 +6,14 @@ export function ListIncomes(projectID) {
   return window.go.service.DataService.ListIncomes(projectID);
 }
 
+export function AddIncome(projectID, source, amount) {
+  return window.go.service.DataService.AddIncome(projectID, source, amount);
+}
+
 export function AddExpense(projectID, category, amount) {
   return window.go.service.DataService.AddExpense(projectID, category, amount);
+}
+
+export function ListExpenses(projectID) {
+  return window.go.service.DataService.ListExpenses(projectID);
 }


### PR DESCRIPTION
## Summary
- add `AddIncome` and `ListExpenses` methods to `DataService`
- expose the methods in Wails bindings
- test the new service methods

## Testing
- `go test ./cmd/... ./internal/... ./internal/pdf/...`

------
https://chatgpt.com/codex/tasks/task_e_68657b292b2c83339c693603e042fca9