### PR TITLE
Remove duplicate React import

### DIFF
--- a/internal/ui/src/App.jsx
+++ b/internal/ui/src/App.jsx
@@ -1,5 +1,4 @@
 import { useState, useEffect } from 'react';
-import { useState, useEffect } from 'react';
 import { AddIncome, ListExpenses } from './wailsjs/go/data/DataService';
 import './index.css';
 


### PR DESCRIPTION
## Summary
- eliminate duplicate import in App.jsx

## Testing
- `go test ./...` in `internal`
- `go test ./...` in `internal/pdf`
- `npm run lint` *(fails: cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6866381f24e083338ab2fa69c933de2d