### PR TITLE
Update CI to Go 1.23

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: '1.20'
+          go-version: '1.23.x'
       - name: Sync Go workspace
         run: go work sync
       - name: Run go vet


### PR DESCRIPTION
## Summary
- use Go 1.23.x in CI to match `go.work`

## Testing
- `go vet ./cmd/... ./internal/... ./internal/pdf/...`
- `go test ./cmd/... ./internal/... ./internal/pdf/...`


------
https://chatgpt.com/codex/tasks/task_e_6866381e17588333a51ad0272a71839c