### PR TITLE
Fix DataService import path

### DIFF
--- a/internal/ui/src/App.jsx
+++ b/internal/ui/src/App.jsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react';
-import { AddExpense, ListExpenses } from './wailsjs/go/data/DataService';
+import { AddExpense, ListExpenses } from './wailsjs/go/service/DataService';
 import './index.css';
 
 function App() {


### PR DESCRIPTION
## Summary
- update App.jsx import path to match generated wailsjs service folder

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6866419481bc83338e749f2d54c64ec7