### PR TITLE
Fix DataService mock path

### DIFF
--- a/internal/ui/src/App.test.jsx
+++ b/internal/ui/src/App.test.jsx
@@ -4,7 +4,7 @@ import { vi } from 'vitest';
 import App from './App';
 
 // mock the DataService module used by App
-vi.mock('./wailsjs/go/data/DataService', () => ({
+vi.mock('./wailsjs/go/service/DataService', () => ({
   AddExpense: vi.fn(),
   ListExpenses: vi.fn(() => Promise.resolve([])),
 }), { virtual: true });


### PR DESCRIPTION
## Summary
- point App.test.jsx at service DataService mock

## Testing
- `bun install` in `internal/ui`
- `bun run test`

------
https://chatgpt.com/codex/tasks/task_e_68664d9ea6d08333aae94ba126a3dbd2