### PR TITLE
Fix artifact path in build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,4 +52,4 @@ jobs:
       uses: actions/upload-artifact@v4
       with:
         name: Baristeuer-${{ matrix.os }}
-        path: build/bin/
+        path: build/bin/**


### PR DESCRIPTION
## Summary
- ensure CI uploads binaries from build/bin/**

## Testing
- `go test ./cmd/... ./internal/... ./internal/pdf...`

------
https://chatgpt.com/codex/tasks/task_e_68664d97cf808333b616b93c75fddd92