### PR TITLE
Fix asset path for Wails build

### DIFF
--- a/wails.json
+++ b/wails.json
@@ -3,7 +3,7 @@
   "name": "Bari$teuer",
   "description": "A tax tool for German non-profit organizations.",
   "outputfilename": "Bari$teuer",
-  "assetdir": ".",
+  "assetdir": "./internal/ui/dist",
   "frontend:dir": "./internal/ui",
   "frontend:install": "npm install",
   "frontend:build": "npm run build",


### PR DESCRIPTION
## Summary
- use the compiled frontend assets in `wails.json`

## Testing
- `go test ./cmd/... ./internal/... ./internal/pdf/...`
- `npm test --prefix internal/ui --silent`
- `npm run build --prefix internal/ui`
- `wails build -ldflags="-s -w" -clean` *(fails: Unable to find Wails in go.mod)*

------
https://chatgpt.com/codex/tasks/task_e_6866753a11708333821b1a8880d238d6