### PR TITLE
Add member management

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Bari$teuer is a software tool designed to assist German non-profit organizations
 
 - **Tax Calculation:** Calculates corporate tax (Körperschaftsteuer) and VAT (Umsatzsteuer) for non-profit organizations based on German tax laws.
 - **Data Management:** Centralized tracking of income, expenses, and donations.
+- **Member Management:** Track club members with join date and contact details.
 - **Tax Overview:** Calculates taxes for a project and displays the results in the UI.
 - **Reporting:** Generates tax reports for submission.
 - **User Interface:** German-language interface styled with Material UI themes.

--- a/docs/DOCUMENTATION.md
+++ b/docs/DOCUMENTATION.md
@@ -58,6 +58,7 @@ also use `go test ./...`, which traverses all modules listed in `go.work`.
 - **React + Material UI Interface**: UI built with React components styled using Material UI.
 - **PDF Generation**: Creates detailed tax reports in PDF format for submission to the German tax office.
 - **SQLite Storage**: Simple persistence layer to store project data.
+- **Member Tracking**: Manage club members with names, emails and join dates.
 - **Unit Tests**: Tests covering the tax calculation logic.
 
 ## Cross-Platform Compatibility

--- a/internal/data/models.go
+++ b/internal/data/models.go
@@ -21,3 +21,11 @@ type Expense struct {
 	Category  string  `db:"category"`
 	Amount    float64 `db:"amount"`
 }
+
+// Member represents a club member.
+type Member struct {
+	ID       int64  `db:"id"`
+	Name     string `db:"name"`
+	Email    string `db:"email"`
+	JoinDate string `db:"join_date"`
+}

--- a/internal/data/store_test.go
+++ b/internal/data/store_test.go
@@ -126,3 +126,45 @@ func TestExpenseCRUD(t *testing.T) {
 		t.Fatalf("expected error after delete")
 	}
 }
+
+func TestMemberCRUD(t *testing.T) {
+	s, err := NewStore(":memory:")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer s.Close()
+
+	m := &Member{Name: "Alice", Email: "alice@example.com", JoinDate: "2024-01-02"}
+	if err := s.CreateMember(m); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := s.GetMember(m.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Email != m.Email {
+		t.Fatalf("expected %s, got %s", m.Email, got.Email)
+	}
+
+	m.Name = "Alice Smith"
+	if err := s.UpdateMember(m); err != nil {
+		t.Fatal(err)
+	}
+	got, _ = s.GetMember(m.ID)
+	if got.Name != "Alice Smith" {
+		t.Fatalf("update failed")
+	}
+
+	members, err := s.ListMembers()
+	if err != nil || len(members) != 1 {
+		t.Fatalf("expected one member, got %v", members)
+	}
+
+	if err := s.DeleteMember(m.ID); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := s.GetMember(m.ID); err == nil {
+		t.Fatalf("expected error after delete")
+	}
+}

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -99,6 +99,26 @@ func (ds *DataService) ListExpenses(projectID int64) ([]data.Expense, error) {
 	return expenses, nil
 }
 
+// AddMember creates a new member.
+func (ds *DataService) AddMember(name, email, joinDate string) (*data.Member, error) {
+	m := &data.Member{Name: name, Email: email, JoinDate: joinDate}
+	if err := ds.store.CreateMember(m); err != nil {
+		return nil, err
+	}
+	ds.logger.Printf("Added member %s", name)
+	return m, nil
+}
+
+// ListMembers returns all members sorted by name.
+func (ds *DataService) ListMembers() ([]data.Member, error) {
+	members, err := ds.store.ListMembers()
+	if err != nil {
+		return nil, err
+	}
+	ds.logger.Printf("Listed %d members", len(members))
+	return members, nil
+}
+
 // CalculateProjectTaxes returns a detailed tax calculation for the given project.
 func (ds *DataService) CalculateProjectTaxes(projectID int64) (taxlogic.TaxResult, error) {
 	revenue, err := ds.store.SumIncomeByProject(projectID)

--- a/internal/service/service_test.go
+++ b/internal/service/service_test.go
@@ -89,3 +89,27 @@ func TestDataService_CalculateProjectTaxes(t *testing.T) {
 		t.Fatalf("expected positive tax, got %f", result.TotalTax)
 	}
 }
+
+func TestDataService_MemberOperations(t *testing.T) {
+	ds, err := NewDataService(":memory:")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ds.Close()
+
+	m, err := ds.AddMember("Bob", "bob@example.com", "2024-01-10")
+	if err != nil {
+		t.Fatalf("AddMember returned error: %v", err)
+	}
+	if m.ID == 0 {
+		t.Fatalf("expected member ID to be set")
+	}
+
+	members, err := ds.ListMembers()
+	if err != nil {
+		t.Fatalf("ListMembers returned error: %v", err)
+	}
+	if len(members) != 1 || members[0].Email != "bob@example.com" {
+		t.Fatalf("unexpected members: %+v", members)
+	}
+}


### PR DESCRIPTION
## Summary
- add Member model and DB table
- implement CRUD methods for members
- expose member operations in service layer
- update README and docs
- test member functionality

## Testing
- `go work sync`
- `go test ./cmd/... ./internal/... ./internal/pdf/...`


------
https://chatgpt.com/codex/tasks/task_e_6866da422f9083338f60b6dcf3c84009