### PR TITLE
Add packaging script

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,18 @@ The resulting binaries can be found in `build/bin`. Follow the official document
 
 See [docs/DOCUMENTATION.md](docs/DOCUMENTATION.md) for more details.
 
+## Packaging
+
+Run the packaging script to build binaries for macOS and Windows and place them
+in versioned directories under `build/bin`:
+
+```bash
+./scripts/package.sh
+```
+
+The script uses `wails build` internally and names the output directory after the
+current Git tag or commit hash.
+
 ---
 
 *This project is for internal use and is not open for contributions.*

--- a/scripts/package.sh
+++ b/scripts/package.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Determine project root (directory containing this script's parent)
+ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$ROOT_DIR"
+
+VERSION="${1:-$(git describe --tags --always)}"
+OUTPUT_DIR="$ROOT_DIR/build/bin/$VERSION"
+
+# Clean output directory
+rm -rf "$OUTPUT_DIR"
+mkdir -p "$OUTPUT_DIR"
+
+PLATFORMS=("darwin/universal" "windows/amd64")
+
+for PLATFORM in "${PLATFORMS[@]}"; do
+    echo "==> Building for $PLATFORM"
+    wails build -clean -platform "$PLATFORM"
+
+    case "$PLATFORM" in
+        darwin/*)  TARGET="macos";;
+        windows/*) TARGET="windows";;
+        *)         TARGET="$PLATFORM";;
+    esac
+
+    mkdir -p "$OUTPUT_DIR/$TARGET"
+    # Move all files produced by this build into the versioned directory
+    mv build/bin/* "$OUTPUT_DIR/$TARGET/"
+    # Prepare for next build
+    rm -rf build/bin
+    mkdir -p build/bin
+done
+
+echo "Artifacts stored in $OUTPUT_DIR"


### PR DESCRIPTION
## Summary
- add script to build and package binaries
- document packaging in README

## Testing
- `go work sync`
- `go test ./cmd/... ./internal/... ./internal/pdf/...`


------
https://chatgpt.com/codex/tasks/task_e_6866f7a93ca88333bcaf2ec6d49ab00f