### PR TITLE
Add context-aware database operations

### DIFF
--- a/internal/data/store.go
+++ b/internal/data/store.go
@@ -1,6 +1,7 @@
 package data
 
 import (
+	"context"
 	"database/sql"
 	_ "github.com/mattn/go-sqlite3"
 )
@@ -61,8 +62,8 @@ func (s *Store) init() error {
 func (s *Store) Close() error { return s.DB.Close() }
 
 // CRUD operations for Project
-func (s *Store) CreateProject(p *Project) error {
-	res, err := s.DB.Exec(`INSERT INTO projects(name) VALUES(?)`, p.Name)
+func (s *Store) CreateProject(ctx context.Context, p *Project) error {
+	res, err := s.DB.ExecContext(ctx, `INSERT INTO projects(name) VALUES(?)`, p.Name)
 	if err != nil {
 		return err
 	}
@@ -70,8 +71,8 @@ func (s *Store) CreateProject(p *Project) error {
 	return err
 }
 
-func (s *Store) GetProject(id int64) (*Project, error) {
-	row := s.DB.QueryRow(`SELECT id, name FROM projects WHERE id=?`, id)
+func (s *Store) GetProject(ctx context.Context, id int64) (*Project, error) {
+	row := s.DB.QueryRowContext(ctx, `SELECT id, name FROM projects WHERE id=?`, id)
 	var p Project
 	if err := row.Scan(&p.ID, &p.Name); err != nil {
 		return nil, err
@@ -79,19 +80,19 @@ func (s *Store) GetProject(id int64) (*Project, error) {
 	return &p, nil
 }
 
-func (s *Store) UpdateProject(p *Project) error {
-	_, err := s.DB.Exec(`UPDATE projects SET name=? WHERE id=?`, p.Name, p.ID)
+func (s *Store) UpdateProject(ctx context.Context, p *Project) error {
+	_, err := s.DB.ExecContext(ctx, `UPDATE projects SET name=? WHERE id=?`, p.Name, p.ID)
 	return err
 }
 
-func (s *Store) DeleteProject(id int64) error {
-	_, err := s.DB.Exec(`DELETE FROM projects WHERE id=?`, id)
+func (s *Store) DeleteProject(ctx context.Context, id int64) error {
+	_, err := s.DB.ExecContext(ctx, `DELETE FROM projects WHERE id=?`, id)
 	return err
 }
 
 // CRUD operations for Income
-func (s *Store) CreateIncome(i *Income) error {
-	res, err := s.DB.Exec(`INSERT INTO incomes(project_id, source, amount) VALUES(?,?,?)`, i.ProjectID, i.Source, i.Amount)
+func (s *Store) CreateIncome(ctx context.Context, i *Income) error {
+	res, err := s.DB.ExecContext(ctx, `INSERT INTO incomes(project_id, source, amount) VALUES(?,?,?)`, i.ProjectID, i.Source, i.Amount)
 	if err != nil {
 		return err
 	}
@@ -99,8 +100,8 @@ func (s *Store) CreateIncome(i *Income) error {
 	return err
 }
 
-func (s *Store) GetIncome(id int64) (*Income, error) {
-	row := s.DB.QueryRow(`SELECT id, project_id, source, amount FROM incomes WHERE id=?`, id)
+func (s *Store) GetIncome(ctx context.Context, id int64) (*Income, error) {
+	row := s.DB.QueryRowContext(ctx, `SELECT id, project_id, source, amount FROM incomes WHERE id=?`, id)
 	var i Income
 	if err := row.Scan(&i.ID, &i.ProjectID, &i.Source, &i.Amount); err != nil {
 		return nil, err
@@ -108,19 +109,19 @@ func (s *Store) GetIncome(id int64) (*Income, error) {
 	return &i, nil
 }
 
-func (s *Store) UpdateIncome(i *Income) error {
-	_, err := s.DB.Exec(`UPDATE incomes SET project_id=?, source=?, amount=? WHERE id=?`, i.ProjectID, i.Source, i.Amount, i.ID)
+func (s *Store) UpdateIncome(ctx context.Context, i *Income) error {
+	_, err := s.DB.ExecContext(ctx, `UPDATE incomes SET project_id=?, source=?, amount=? WHERE id=?`, i.ProjectID, i.Source, i.Amount, i.ID)
 	return err
 }
 
-func (s *Store) DeleteIncome(id int64) error {
-	_, err := s.DB.Exec(`DELETE FROM incomes WHERE id=?`, id)
+func (s *Store) DeleteIncome(ctx context.Context, id int64) error {
+	_, err := s.DB.ExecContext(ctx, `DELETE FROM incomes WHERE id=?`, id)
 	return err
 }
 
 // CRUD operations for Expense
-func (s *Store) CreateExpense(e *Expense) error {
-	res, err := s.DB.Exec(`INSERT INTO expenses(project_id, category, amount) VALUES(?,?,?)`, e.ProjectID, e.Category, e.Amount)
+func (s *Store) CreateExpense(ctx context.Context, e *Expense) error {
+	res, err := s.DB.ExecContext(ctx, `INSERT INTO expenses(project_id, category, amount) VALUES(?,?,?)`, e.ProjectID, e.Category, e.Amount)
 	if err != nil {
 		return err
 	}
@@ -128,8 +129,8 @@ func (s *Store) CreateExpense(e *Expense) error {
 	return err
 }
 
-func (s *Store) GetExpense(id int64) (*Expense, error) {
-	row := s.DB.QueryRow(`SELECT id, project_id, category, amount FROM expenses WHERE id=?`, id)
+func (s *Store) GetExpense(ctx context.Context, id int64) (*Expense, error) {
+	row := s.DB.QueryRowContext(ctx, `SELECT id, project_id, category, amount FROM expenses WHERE id=?`, id)
 	var e Expense
 	if err := row.Scan(&e.ID, &e.ProjectID, &e.Category, &e.Amount); err != nil {
 		return nil, err
@@ -137,19 +138,19 @@ func (s *Store) GetExpense(id int64) (*Expense, error) {
 	return &e, nil
 }
 
-func (s *Store) UpdateExpense(e *Expense) error {
-	_, err := s.DB.Exec(`UPDATE expenses SET project_id=?, category=?, amount=? WHERE id=?`, e.ProjectID, e.Category, e.Amount, e.ID)
+func (s *Store) UpdateExpense(ctx context.Context, e *Expense) error {
+	_, err := s.DB.ExecContext(ctx, `UPDATE expenses SET project_id=?, category=?, amount=? WHERE id=?`, e.ProjectID, e.Category, e.Amount, e.ID)
 	return err
 }
 
-func (s *Store) DeleteExpense(id int64) error {
-	_, err := s.DB.Exec(`DELETE FROM expenses WHERE id=?`, id)
+func (s *Store) DeleteExpense(ctx context.Context, id int64) error {
+	_, err := s.DB.ExecContext(ctx, `DELETE FROM expenses WHERE id=?`, id)
 	return err
 }
 
 // SumIncomeByProject returns the total income amount for a project.
-func (s *Store) SumIncomeByProject(projectID int64) (float64, error) {
-	row := s.DB.QueryRow(`SELECT COALESCE(SUM(amount),0) FROM incomes WHERE project_id=?`, projectID)
+func (s *Store) SumIncomeByProject(ctx context.Context, projectID int64) (float64, error) {
+	row := s.DB.QueryRowContext(ctx, `SELECT COALESCE(SUM(amount),0) FROM incomes WHERE project_id=?`, projectID)
 	var total float64
 	if err := row.Scan(&total); err != nil {
 		return 0, err
@@ -158,8 +159,8 @@ func (s *Store) SumIncomeByProject(projectID int64) (float64, error) {
 }
 
 // SumExpenseByProject returns the total expense amount for a project.
-func (s *Store) SumExpenseByProject(projectID int64) (float64, error) {
-	row := s.DB.QueryRow(`SELECT COALESCE(SUM(amount),0) FROM expenses WHERE project_id=?`, projectID)
+func (s *Store) SumExpenseByProject(ctx context.Context, projectID int64) (float64, error) {
+	row := s.DB.QueryRowContext(ctx, `SELECT COALESCE(SUM(amount),0) FROM expenses WHERE project_id=?`, projectID)
 	var total float64
 	if err := row.Scan(&total); err != nil {
 		return 0, err
@@ -168,8 +169,8 @@ func (s *Store) SumExpenseByProject(projectID int64) (float64, error) {
 }
 
 // CRUD operations for Member
-func (s *Store) CreateMember(m *Member) error {
-	res, err := s.DB.Exec(`INSERT INTO members(name, email, join_date) VALUES(?,?,?)`, m.Name, m.Email, m.JoinDate)
+func (s *Store) CreateMember(ctx context.Context, m *Member) error {
+	res, err := s.DB.ExecContext(ctx, `INSERT INTO members(name, email, join_date) VALUES(?,?,?)`, m.Name, m.Email, m.JoinDate)
 	if err != nil {
 		return err
 	}
@@ -177,8 +178,8 @@ func (s *Store) CreateMember(m *Member) error {
 	return err
 }
 
-func (s *Store) GetMember(id int64) (*Member, error) {
-	row := s.DB.QueryRow(`SELECT id, name, email, join_date FROM members WHERE id=?`, id)
+func (s *Store) GetMember(ctx context.Context, id int64) (*Member, error) {
+	row := s.DB.QueryRowContext(ctx, `SELECT id, name, email, join_date FROM members WHERE id=?`, id)
 	var m Member
 	if err := row.Scan(&m.ID, &m.Name, &m.Email, &m.JoinDate); err != nil {
 		return nil, err
@@ -186,18 +187,18 @@ func (s *Store) GetMember(id int64) (*Member, error) {
 	return &m, nil
 }
 
-func (s *Store) UpdateMember(m *Member) error {
-	_, err := s.DB.Exec(`UPDATE members SET name=?, email=?, join_date=? WHERE id=?`, m.Name, m.Email, m.JoinDate, m.ID)
+func (s *Store) UpdateMember(ctx context.Context, m *Member) error {
+	_, err := s.DB.ExecContext(ctx, `UPDATE members SET name=?, email=?, join_date=? WHERE id=?`, m.Name, m.Email, m.JoinDate, m.ID)
 	return err
 }
 
-func (s *Store) DeleteMember(id int64) error {
-	_, err := s.DB.Exec(`DELETE FROM members WHERE id=?`, id)
+func (s *Store) DeleteMember(ctx context.Context, id int64) error {
+	_, err := s.DB.ExecContext(ctx, `DELETE FROM members WHERE id=?`, id)
 	return err
 }
 
-func (s *Store) ListMembers() ([]Member, error) {
-	rows, err := s.DB.Query(`SELECT id, name, email, join_date FROM members ORDER BY name`)
+func (s *Store) ListMembers(ctx context.Context) ([]Member, error) {
+	rows, err := s.DB.QueryContext(ctx, `SELECT id, name, email, join_date FROM members ORDER BY name`)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/data/store_test.go
+++ b/internal/data/store_test.go
@@ -1,6 +1,10 @@
 package data
 
-import "testing"
+import (
+	"context"
+	"errors"
+	"testing"
+)
 
 func TestProjectCRUD(t *testing.T) {
 	s, err := NewStore(":memory:")
@@ -9,12 +13,13 @@ func TestProjectCRUD(t *testing.T) {
 	}
 	defer s.Close()
 
+	ctx := context.Background()
 	p := &Project{Name: "Test"}
-	if err := s.CreateProject(p); err != nil {
+	if err := s.CreateProject(ctx, p); err != nil {
 		t.Fatal(err)
 	}
 
-	got, err := s.GetProject(p.ID)
+	got, err := s.GetProject(ctx, p.ID)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -23,11 +28,11 @@ func TestProjectCRUD(t *testing.T) {
 	}
 
 	p.Name = "Updated"
-	if err := s.UpdateProject(p); err != nil {
+	if err := s.UpdateProject(ctx, p); err != nil {
 		t.Fatal(err)
 	}
 
-	got, err = s.GetProject(p.ID)
+	got, err = s.GetProject(ctx, p.ID)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -35,10 +40,10 @@ func TestProjectCRUD(t *testing.T) {
 		t.Fatalf("update failed: got %s", got.Name)
 	}
 
-	if err := s.DeleteProject(p.ID); err != nil {
+	if err := s.DeleteProject(ctx, p.ID); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := s.GetProject(p.ID); err == nil {
+	if _, err := s.GetProject(ctx, p.ID); err == nil {
 		t.Fatalf("expected error after delete")
 	}
 }
@@ -50,17 +55,18 @@ func TestIncomeCRUD(t *testing.T) {
 	}
 	defer s.Close()
 
+	ctx := context.Background()
 	proj := &Project{Name: "Income Project"}
-	if err := s.CreateProject(proj); err != nil {
+	if err := s.CreateProject(ctx, proj); err != nil {
 		t.Fatal(err)
 	}
 
 	i := &Income{ProjectID: proj.ID, Source: "donation", Amount: 10}
-	if err := s.CreateIncome(i); err != nil {
+	if err := s.CreateIncome(ctx, i); err != nil {
 		t.Fatal(err)
 	}
 
-	got, err := s.GetIncome(i.ID)
+	got, err := s.GetIncome(ctx, i.ID)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -69,18 +75,18 @@ func TestIncomeCRUD(t *testing.T) {
 	}
 
 	i.Amount = 20
-	if err := s.UpdateIncome(i); err != nil {
+	if err := s.UpdateIncome(ctx, i); err != nil {
 		t.Fatal(err)
 	}
-	got, _ = s.GetIncome(i.ID)
+	got, _ = s.GetIncome(ctx, i.ID)
 	if got.Amount != 20 {
 		t.Fatalf("update failed")
 	}
 
-	if err := s.DeleteIncome(i.ID); err != nil {
+	if err := s.DeleteIncome(ctx, i.ID); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := s.GetIncome(i.ID); err == nil {
+	if _, err := s.GetIncome(ctx, i.ID); err == nil {
 		t.Fatalf("expected error after delete")
 	}
 }
@@ -92,17 +98,18 @@ func TestExpenseCRUD(t *testing.T) {
 	}
 	defer s.Close()
 
+	ctx := context.Background()
 	proj := &Project{Name: "Expense Project"}
-	if err := s.CreateProject(proj); err != nil {
+	if err := s.CreateProject(ctx, proj); err != nil {
 		t.Fatal(err)
 	}
 
 	e := &Expense{ProjectID: proj.ID, Category: "supplies", Amount: 5}
-	if err := s.CreateExpense(e); err != nil {
+	if err := s.CreateExpense(ctx, e); err != nil {
 		t.Fatal(err)
 	}
 
-	got, err := s.GetExpense(e.ID)
+	got, err := s.GetExpense(ctx, e.ID)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -111,18 +118,18 @@ func TestExpenseCRUD(t *testing.T) {
 	}
 
 	e.Amount = 8
-	if err := s.UpdateExpense(e); err != nil {
+	if err := s.UpdateExpense(ctx, e); err != nil {
 		t.Fatal(err)
 	}
-	got, _ = s.GetExpense(e.ID)
+	got, _ = s.GetExpense(ctx, e.ID)
 	if got.Amount != 8 {
 		t.Fatalf("update failed")
 	}
 
-	if err := s.DeleteExpense(e.ID); err != nil {
+	if err := s.DeleteExpense(ctx, e.ID); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := s.GetExpense(e.ID); err == nil {
+	if _, err := s.GetExpense(ctx, e.ID); err == nil {
 		t.Fatalf("expected error after delete")
 	}
 }
@@ -134,12 +141,13 @@ func TestMemberCRUD(t *testing.T) {
 	}
 	defer s.Close()
 
+	ctx := context.Background()
 	m := &Member{Name: "Alice", Email: "alice@example.com", JoinDate: "2024-01-02"}
-	if err := s.CreateMember(m); err != nil {
+	if err := s.CreateMember(ctx, m); err != nil {
 		t.Fatal(err)
 	}
 
-	got, err := s.GetMember(m.ID)
+	got, err := s.GetMember(ctx, m.ID)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -148,23 +156,38 @@ func TestMemberCRUD(t *testing.T) {
 	}
 
 	m.Name = "Alice Smith"
-	if err := s.UpdateMember(m); err != nil {
+	if err := s.UpdateMember(ctx, m); err != nil {
 		t.Fatal(err)
 	}
-	got, _ = s.GetMember(m.ID)
+	got, _ = s.GetMember(ctx, m.ID)
 	if got.Name != "Alice Smith" {
 		t.Fatalf("update failed")
 	}
 
-	members, err := s.ListMembers()
+	members, err := s.ListMembers(ctx)
 	if err != nil || len(members) != 1 {
 		t.Fatalf("expected one member, got %v", members)
 	}
 
-	if err := s.DeleteMember(m.ID); err != nil {
+	if err := s.DeleteMember(ctx, m.ID); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := s.GetMember(m.ID); err == nil {
+	if _, err := s.GetMember(ctx, m.ID); err == nil {
 		t.Fatalf("expected error after delete")
+	}
+}
+
+func TestStore_ContextCancellation(t *testing.T) {
+	s, err := NewStore(":memory:")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer s.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	err = s.CreateProject(ctx, &Project{Name: "ctx"})
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected context canceled, got %v", err)
 	}
 }

--- a/internal/pdf/pdf.go
+++ b/internal/pdf/pdf.go
@@ -1,6 +1,7 @@
 package pdf
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -28,11 +29,12 @@ func NewGenerator(basePath string, store *data.Store) *Generator {
 
 // GenerateReport creates a tax report PDF for the given project.
 func (g *Generator) GenerateReport(projectID int64) (string, error) {
-	revenue, err := g.store.SumIncomeByProject(projectID)
+	ctx := context.Background()
+	revenue, err := g.store.SumIncomeByProject(ctx, projectID)
 	if err != nil {
 		return "", fmt.Errorf("fetch revenue: %w", err)
 	}
-	expenses, err := g.store.SumExpenseByProject(projectID)
+	expenses, err := g.store.SumExpenseByProject(ctx, projectID)
 	if err != nil {
 		return "", fmt.Errorf("fetch expenses: %w", err)
 	}
@@ -110,7 +112,7 @@ func (g *Generator) GenerateReport(projectID int64) (string, error) {
 
 // GenerateKSt1 creates a placeholder "KSt 1" form for the given project.
 func (g *Generator) GenerateKSt1(projectID int64) (string, error) {
-	p, _ := g.store.GetProject(projectID)
+	p, _ := g.store.GetProject(context.Background(), projectID)
 	nameLine := "Name des Vereins: ____________________"
 	if p != nil {
 		nameLine = fmt.Sprintf("Name des Vereins: %s", p.Name)
@@ -127,7 +129,7 @@ func (g *Generator) GenerateKSt1(projectID int64) (string, error) {
 
 // GenerateAnlageGem creates a placeholder "Anlage Gem" form for the given project.
 func (g *Generator) GenerateAnlageGem(projectID int64) (string, error) {
-	p, _ := g.store.GetProject(projectID)
+	p, _ := g.store.GetProject(context.Background(), projectID)
 	prefix := "Anlage Gem - Angaben zur Gemeinn\xC3\xBCtzigkeit"
 	if p != nil {
 		prefix = fmt.Sprintf("Anlage Gem - %s", p.Name)
@@ -143,7 +145,7 @@ func (g *Generator) GenerateAnlageGem(projectID int64) (string, error) {
 
 // GenerateAnlageGK creates a placeholder "Anlage GK" form for the given project.
 func (g *Generator) GenerateAnlageGK(projectID int64) (string, error) {
-	p, _ := g.store.GetProject(projectID)
+	p, _ := g.store.GetProject(context.Background(), projectID)
 	title := "Anlage GK - Angaben zu Gesch\xC3\xA4ftsbetrieben"
 	if p != nil {
 		title = fmt.Sprintf("Anlage GK - %s", p.Name)
@@ -159,7 +161,7 @@ func (g *Generator) GenerateAnlageGK(projectID int64) (string, error) {
 
 // GenerateKSt1F creates a placeholder "KSt 1F" form for the given project.
 func (g *Generator) GenerateKSt1F(projectID int64) (string, error) {
-	p, _ := g.store.GetProject(projectID)
+	p, _ := g.store.GetProject(context.Background(), projectID)
 	title := "KSt 1F - Erweiterte K\xC3\xB6rperschaftsteuererkl\xC3\xA4rung"
 	if p != nil {
 		title = fmt.Sprintf("KSt 1F - %s", p.Name)
@@ -175,7 +177,7 @@ func (g *Generator) GenerateKSt1F(projectID int64) (string, error) {
 
 // GenerateAnlageSport creates a placeholder "Anlage Sport" form for the given project.
 func (g *Generator) GenerateAnlageSport(projectID int64) (string, error) {
-	p, _ := g.store.GetProject(projectID)
+	p, _ := g.store.GetProject(context.Background(), projectID)
 	title := "Anlage Sport - Sportvereine"
 	if p != nil {
 		title = fmt.Sprintf("Anlage Sport - %s", p.Name)

--- a/internal/pdf/pdf_test.go
+++ b/internal/pdf/pdf_test.go
@@ -1,6 +1,7 @@
 package pdf
 
 import (
+	"context"
 	"os"
 	"strings"
 	"testing"
@@ -16,14 +17,15 @@ func TestGenerateReport(t *testing.T) {
 	}
 	defer store.Close()
 
+	ctx := context.Background()
 	proj := &data.Project{Name: "Test"}
-	if err := store.CreateProject(proj); err != nil {
+	if err := store.CreateProject(ctx, proj); err != nil {
 		t.Fatal(err)
 	}
-	if err := store.CreateIncome(&data.Income{ProjectID: proj.ID, Source: "donation", Amount: 100}); err != nil {
+	if err := store.CreateIncome(ctx, &data.Income{ProjectID: proj.ID, Source: "donation", Amount: 100}); err != nil {
 		t.Fatal(err)
 	}
-	if err := store.CreateExpense(&data.Expense{ProjectID: proj.ID, Category: "supplies", Amount: 20}); err != nil {
+	if err := store.CreateExpense(ctx, &data.Expense{ProjectID: proj.ID, Category: "supplies", Amount: 20}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -45,8 +47,9 @@ func TestFormGeneration(t *testing.T) {
 	}
 	defer store.Close()
 
+	ctx := context.Background()
 	proj := &data.Project{Name: "Test"}
-	if err := store.CreateProject(proj); err != nil {
+	if err := store.CreateProject(ctx, proj); err != nil {
 		t.Fatal(err)
 	}
 

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -3,6 +3,7 @@ package service
 import (
 	"baristeuer/internal/data"
 	"baristeuer/internal/taxlogic"
+	"context"
 	"log"
 	"os"
 )
@@ -30,9 +31,9 @@ func NewDataServiceFromStore(store *data.Store) *DataService {
 }
 
 // CreateProject creates a project by name.
-func (ds *DataService) CreateProject(name string) (*data.Project, error) {
+func (ds *DataService) CreateProject(ctx context.Context, name string) (*data.Project, error) {
 	p := &data.Project{Name: name}
-	if err := ds.store.CreateProject(p); err != nil {
+	if err := ds.store.CreateProject(ctx, p); err != nil {
 		return nil, err
 	}
 	ds.logger.Printf("Created project %d", p.ID)
@@ -40,8 +41,8 @@ func (ds *DataService) CreateProject(name string) (*data.Project, error) {
 }
 
 // ListIncomes returns all incomes for the given project.
-func (ds *DataService) ListIncomes(projectID int64) ([]data.Income, error) {
-	rows, err := ds.store.DB.Query(`SELECT id, project_id, source, amount FROM incomes WHERE project_id=?`, projectID)
+func (ds *DataService) ListIncomes(ctx context.Context, projectID int64) ([]data.Income, error) {
+	rows, err := ds.store.DB.QueryContext(ctx, `SELECT id, project_id, source, amount FROM incomes WHERE project_id=?`, projectID)
 	if err != nil {
 		return nil, err
 	}
@@ -60,9 +61,9 @@ func (ds *DataService) ListIncomes(projectID int64) ([]data.Income, error) {
 }
 
 // AddIncome adds a new income to the given project.
-func (ds *DataService) AddIncome(projectID int64, source string, amount float64) (*data.Income, error) {
+func (ds *DataService) AddIncome(ctx context.Context, projectID int64, source string, amount float64) (*data.Income, error) {
 	i := &data.Income{ProjectID: projectID, Source: source, Amount: amount}
-	if err := ds.store.CreateIncome(i); err != nil {
+	if err := ds.store.CreateIncome(ctx, i); err != nil {
 		return nil, err
 	}
 	ds.logger.Printf("Added income %.2f to project %d", amount, projectID)
@@ -70,9 +71,9 @@ func (ds *DataService) AddIncome(projectID int64, source string, amount float64)
 }
 
 // UpdateIncome updates an existing income entry.
-func (ds *DataService) UpdateIncome(id int64, projectID int64, source string, amount float64) error {
+func (ds *DataService) UpdateIncome(ctx context.Context, id int64, projectID int64, source string, amount float64) error {
 	i := &data.Income{ID: id, ProjectID: projectID, Source: source, Amount: amount}
-	if err := ds.store.UpdateIncome(i); err != nil {
+	if err := ds.store.UpdateIncome(ctx, i); err != nil {
 		return err
 	}
 	ds.logger.Printf("Updated income %d", id)
@@ -80,8 +81,8 @@ func (ds *DataService) UpdateIncome(id int64, projectID int64, source string, am
 }
 
 // DeleteIncome removes an income entry by ID.
-func (ds *DataService) DeleteIncome(id int64) error {
-	if err := ds.store.DeleteIncome(id); err != nil {
+func (ds *DataService) DeleteIncome(ctx context.Context, id int64) error {
+	if err := ds.store.DeleteIncome(ctx, id); err != nil {
 		return err
 	}
 	ds.logger.Printf("Deleted income %d", id)
@@ -89,9 +90,9 @@ func (ds *DataService) DeleteIncome(id int64) error {
 }
 
 // AddExpense adds a new expense to the given project.
-func (ds *DataService) AddExpense(projectID int64, category string, amount float64) (*data.Expense, error) {
+func (ds *DataService) AddExpense(ctx context.Context, projectID int64, category string, amount float64) (*data.Expense, error) {
 	e := &data.Expense{ProjectID: projectID, Category: category, Amount: amount}
-	if err := ds.store.CreateExpense(e); err != nil {
+	if err := ds.store.CreateExpense(ctx, e); err != nil {
 		return nil, err
 	}
 	ds.logger.Printf("Added expense %.2f to project %d", amount, projectID)
@@ -99,9 +100,9 @@ func (ds *DataService) AddExpense(projectID int64, category string, amount float
 }
 
 // UpdateExpense updates an existing expense entry.
-func (ds *DataService) UpdateExpense(id int64, projectID int64, category string, amount float64) error {
+func (ds *DataService) UpdateExpense(ctx context.Context, id int64, projectID int64, category string, amount float64) error {
 	e := &data.Expense{ID: id, ProjectID: projectID, Category: category, Amount: amount}
-	if err := ds.store.UpdateExpense(e); err != nil {
+	if err := ds.store.UpdateExpense(ctx, e); err != nil {
 		return err
 	}
 	ds.logger.Printf("Updated expense %d", id)
@@ -109,8 +110,8 @@ func (ds *DataService) UpdateExpense(id int64, projectID int64, category string,
 }
 
 // DeleteExpense removes an expense entry by ID.
-func (ds *DataService) DeleteExpense(id int64) error {
-	if err := ds.store.DeleteExpense(id); err != nil {
+func (ds *DataService) DeleteExpense(ctx context.Context, id int64) error {
+	if err := ds.store.DeleteExpense(ctx, id); err != nil {
 		return err
 	}
 	ds.logger.Printf("Deleted expense %d", id)
@@ -118,8 +119,8 @@ func (ds *DataService) DeleteExpense(id int64) error {
 }
 
 // ListExpenses returns all expenses for the given project.
-func (ds *DataService) ListExpenses(projectID int64) ([]data.Expense, error) {
-	rows, err := ds.store.DB.Query(`SELECT id, project_id, category, amount FROM expenses WHERE project_id=?`, projectID)
+func (ds *DataService) ListExpenses(ctx context.Context, projectID int64) ([]data.Expense, error) {
+	rows, err := ds.store.DB.QueryContext(ctx, `SELECT id, project_id, category, amount FROM expenses WHERE project_id=?`, projectID)
 	if err != nil {
 		return nil, err
 	}
@@ -138,9 +139,9 @@ func (ds *DataService) ListExpenses(projectID int64) ([]data.Expense, error) {
 }
 
 // AddMember creates a new member.
-func (ds *DataService) AddMember(name, email, joinDate string) (*data.Member, error) {
+func (ds *DataService) AddMember(ctx context.Context, name, email, joinDate string) (*data.Member, error) {
 	m := &data.Member{Name: name, Email: email, JoinDate: joinDate}
-	if err := ds.store.CreateMember(m); err != nil {
+	if err := ds.store.CreateMember(ctx, m); err != nil {
 		return nil, err
 	}
 	ds.logger.Printf("Added member %s", name)
@@ -148,8 +149,8 @@ func (ds *DataService) AddMember(name, email, joinDate string) (*data.Member, er
 }
 
 // ListMembers returns all members sorted by name.
-func (ds *DataService) ListMembers() ([]data.Member, error) {
-	members, err := ds.store.ListMembers()
+func (ds *DataService) ListMembers(ctx context.Context) ([]data.Member, error) {
+	members, err := ds.store.ListMembers(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -158,12 +159,12 @@ func (ds *DataService) ListMembers() ([]data.Member, error) {
 }
 
 // CalculateProjectTaxes returns a detailed tax calculation for the given project.
-func (ds *DataService) CalculateProjectTaxes(projectID int64) (taxlogic.TaxResult, error) {
-	revenue, err := ds.store.SumIncomeByProject(projectID)
+func (ds *DataService) CalculateProjectTaxes(ctx context.Context, projectID int64) (taxlogic.TaxResult, error) {
+	revenue, err := ds.store.SumIncomeByProject(ctx, projectID)
 	if err != nil {
 		return taxlogic.TaxResult{}, err
 	}
-	expenses, err := ds.store.SumExpenseByProject(projectID)
+	expenses, err := ds.store.SumExpenseByProject(ctx, projectID)
 	if err != nil {
 		return taxlogic.TaxResult{}, err
 	}

--- a/internal/service/service_test.go
+++ b/internal/service/service_test.go
@@ -1,6 +1,10 @@
 package service
 
-import "testing"
+import (
+	"context"
+	"errors"
+	"testing"
+)
 
 func TestDataService_AddIncome(t *testing.T) {
 	ds, err := NewDataService(":memory:")
@@ -9,12 +13,13 @@ func TestDataService_AddIncome(t *testing.T) {
 	}
 	defer ds.Close()
 
-	proj, err := ds.CreateProject("Income Project")
+	ctx := context.Background()
+	proj, err := ds.CreateProject(ctx, "Income Project")
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	inc, err := ds.AddIncome(proj.ID, "donation", 15)
+	inc, err := ds.AddIncome(ctx, proj.ID, "donation", 15)
 	if err != nil {
 		t.Fatalf("AddIncome returned error: %v", err)
 	}
@@ -22,7 +27,7 @@ func TestDataService_AddIncome(t *testing.T) {
 		t.Fatalf("expected income ID to be set")
 	}
 
-	list, err := ds.ListIncomes(proj.ID)
+	list, err := ds.ListIncomes(ctx, proj.ID)
 	if err != nil {
 		t.Fatalf("ListIncomes returned error: %v", err)
 	}
@@ -38,29 +43,30 @@ func TestDataService_UpdateDeleteIncome(t *testing.T) {
 	}
 	defer ds.Close()
 
-	proj, err := ds.CreateProject("Income UD")
+	ctx := context.Background()
+	proj, err := ds.CreateProject(ctx, "Income UD")
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	inc, err := ds.AddIncome(proj.ID, "donation", 10)
+	inc, err := ds.AddIncome(ctx, proj.ID, "donation", 10)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	if err := ds.UpdateIncome(inc.ID, proj.ID, "donation", 20); err != nil {
+	if err := ds.UpdateIncome(ctx, inc.ID, proj.ID, "donation", 20); err != nil {
 		t.Fatalf("UpdateIncome failed: %v", err)
 	}
 
-	list, _ := ds.ListIncomes(proj.ID)
+	list, _ := ds.ListIncomes(ctx, proj.ID)
 	if len(list) != 1 || list[0].Amount != 20 {
 		t.Fatalf("update failed: %+v", list)
 	}
 
-	if err := ds.DeleteIncome(inc.ID); err != nil {
+	if err := ds.DeleteIncome(ctx, inc.ID); err != nil {
 		t.Fatalf("DeleteIncome failed: %v", err)
 	}
-	list, _ = ds.ListIncomes(proj.ID)
+	list, _ = ds.ListIncomes(ctx, proj.ID)
 	if len(list) != 0 {
 		t.Fatalf("expected empty list, got %+v", list)
 	}
@@ -73,19 +79,20 @@ func TestDataService_ListExpenses(t *testing.T) {
 	}
 	defer ds.Close()
 
-	proj, err := ds.CreateProject("Expense Project")
+	ctx := context.Background()
+	proj, err := ds.CreateProject(ctx, "Expense Project")
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	if _, err := ds.AddExpense(proj.ID, "supplies", 5); err != nil {
+	if _, err := ds.AddExpense(ctx, proj.ID, "supplies", 5); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := ds.AddExpense(proj.ID, "food", 7); err != nil {
+	if _, err := ds.AddExpense(ctx, proj.ID, "food", 7); err != nil {
 		t.Fatal(err)
 	}
 
-	expenses, err := ds.ListExpenses(proj.ID)
+	expenses, err := ds.ListExpenses(ctx, proj.ID)
 	if err != nil {
 		t.Fatalf("ListExpenses returned error: %v", err)
 	}
@@ -101,29 +108,30 @@ func TestDataService_UpdateDeleteExpense(t *testing.T) {
 	}
 	defer ds.Close()
 
-	proj, err := ds.CreateProject("Expense UD")
+	ctx := context.Background()
+	proj, err := ds.CreateProject(ctx, "Expense UD")
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	exp, err := ds.AddExpense(proj.ID, "supplies", 5)
+	exp, err := ds.AddExpense(ctx, proj.ID, "supplies", 5)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	if err := ds.UpdateExpense(exp.ID, proj.ID, "supplies", 8); err != nil {
+	if err := ds.UpdateExpense(ctx, exp.ID, proj.ID, "supplies", 8); err != nil {
 		t.Fatalf("UpdateExpense failed: %v", err)
 	}
 
-	list, _ := ds.ListExpenses(proj.ID)
+	list, _ := ds.ListExpenses(ctx, proj.ID)
 	if len(list) != 1 || list[0].Amount != 8 {
 		t.Fatalf("update failed: %+v", list)
 	}
 
-	if err := ds.DeleteExpense(exp.ID); err != nil {
+	if err := ds.DeleteExpense(ctx, exp.ID); err != nil {
 		t.Fatalf("DeleteExpense failed: %v", err)
 	}
-	list, _ = ds.ListExpenses(proj.ID)
+	list, _ = ds.ListExpenses(ctx, proj.ID)
 	if len(list) != 0 {
 		t.Fatalf("expected empty list, got %+v", list)
 	}
@@ -136,19 +144,20 @@ func TestDataService_CalculateProjectTaxes(t *testing.T) {
 	}
 	defer ds.Close()
 
-	proj, err := ds.CreateProject("Tax Project")
+	ctx := context.Background()
+	proj, err := ds.CreateProject(ctx, "Tax Project")
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	if _, err := ds.AddIncome(proj.ID, "donation", 50000); err != nil {
+	if _, err := ds.AddIncome(ctx, proj.ID, "donation", 50000); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := ds.AddExpense(proj.ID, "rent", 2000); err != nil {
+	if _, err := ds.AddExpense(ctx, proj.ID, "rent", 2000); err != nil {
 		t.Fatal(err)
 	}
 
-	result, err := ds.CalculateProjectTaxes(proj.ID)
+	result, err := ds.CalculateProjectTaxes(ctx, proj.ID)
 	if err != nil {
 		t.Fatalf("CalculateProjectTaxes returned error: %v", err)
 	}
@@ -167,7 +176,8 @@ func TestDataService_MemberOperations(t *testing.T) {
 	}
 	defer ds.Close()
 
-	m, err := ds.AddMember("Bob", "bob@example.com", "2024-01-10")
+	ctx := context.Background()
+	m, err := ds.AddMember(ctx, "Bob", "bob@example.com", "2024-01-10")
 	if err != nil {
 		t.Fatalf("AddMember returned error: %v", err)
 	}
@@ -175,11 +185,32 @@ func TestDataService_MemberOperations(t *testing.T) {
 		t.Fatalf("expected member ID to be set")
 	}
 
-	members, err := ds.ListMembers()
+	members, err := ds.ListMembers(ctx)
 	if err != nil {
 		t.Fatalf("ListMembers returned error: %v", err)
 	}
 	if len(members) != 1 || members[0].Email != "bob@example.com" {
 		t.Fatalf("unexpected members: %+v", members)
+	}
+}
+
+func TestDataService_ContextCancellation(t *testing.T) {
+	ds, err := NewDataService(":memory:")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ds.Close()
+
+	ctx := context.Background()
+	proj, err := ds.CreateProject(ctx, "ctx")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cctx, cancel := context.WithCancel(ctx)
+	cancel()
+	_, err = ds.AddIncome(cctx, proj.ID, "donation", 1)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected context canceled, got %v", err)
 	}
 }


### PR DESCRIPTION
## Summary
- pass `context.Context` through data store methods
- update service layer to propagate contexts
- adjust PDF generator to use contexts
- modify tests for context support and add cancellation tests

## Testing
- `go test ./internal/... ./internal/pdf/...`

------
https://chatgpt.com/codex/tasks/task_e_6866f7a664b883339f84614232c4c977