### PR TITLE
Expand app with member management and form archive

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,13 @@ npm run build --prefix internal/ui
 wails build -clean
 ```
 
-The resulting binaries can be found in `build/bin`. Follow the official documentation for platform specific details.
+The resulting binaries can be found in `build/bin`. Use `-db`, `-pdfdir`, `-year` and `-loglevel` flags to specify a custom SQLite file, PDF output directory, tax year and log verbosity, e.g.:
+
+```bash
+./baristeuer -db mydata.db -pdfdir ./reports -year 2025 -loglevel debug
+```
+
+Follow the official documentation for platform specific details.
 
 ## Testing
 
@@ -50,7 +56,7 @@ See [docs/DOCUMENTATION.md](docs/DOCUMENTATION.md) for more details.
 
 ## Packaging
 
-Run the packaging script to build binaries for macOS and Windows and place them
+Run the packaging script to build binaries for macOS, Windows and Linux and place them
 in versioned directories under `build/bin`:
 
 ```bash

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -1,29 +1,43 @@
 package main
 
 import (
-        "baristeuer/internal/data"
-        "baristeuer/internal/pdf"
-        "baristeuer/internal/service"
-        "github.com/wailsapp/wails/v2"
-        "github.com/wailsapp/wails/v2/pkg/options"
-        "github.com/wailsapp/wails/v2/pkg/options/assetserver"
+	"baristeuer/internal/data"
+	"baristeuer/internal/pdf"
+	"baristeuer/internal/service"
+	"baristeuer/internal/taxlogic"
+	"flag"
+	"github.com/wailsapp/wails/v2"
+	"github.com/wailsapp/wails/v2/pkg/options"
+	"github.com/wailsapp/wails/v2/pkg/options/assetserver"
+	"os"
 )
 
 func main() {
-	store, err := data.NewStore("baristeuer.db")
+	dbPath := flag.String("db", "baristeuer.db", "SQLite database path")
+	pdfDir := flag.String("pdfdir", "", "directory for generated PDFs")
+	year := flag.Int("year", 2025, "tax year for calculations")
+	logLevel := flag.String("loglevel", "", "log level (debug|info|warn|error)")
+	flag.Parse()
+
+	if *logLevel != "" {
+		os.Setenv("LOG_LEVEL", *logLevel)
+	}
+
+	store, err := data.NewStore(*dbPath)
 	if err != nil {
 		println("Error:", err.Error())
 		return
 	}
 	defer store.Close()
 
-        generator := pdf.NewGenerator("", store)
-        datasvc, err := service.NewDataService("baristeuer.db")
-        if err != nil {
-                println("Error:", err.Error())
-                return
-        }
-        defer datasvc.Close()
+	generator := pdf.NewGenerator(*pdfDir, store, *year)
+	cfg := taxlogic.ConfigForYear(*year)
+	datasvc, err := service.NewDataServiceWithConfig(*dbPath, cfg)
+	if err != nil {
+		println("Error:", err.Error())
+		return
+	}
+	defer datasvc.Close()
 
 	err = wails.Run(&options.App{
 		Title:       "Baristeuer",

--- a/docs/DOCUMENTATION.md
+++ b/docs/DOCUMENTATION.md
@@ -53,6 +53,17 @@ Running the command after `go work sync` ensures all workspace modules are
 included and prevents missing dependency errors. With Go 1.23 or newer you can
 also use `go test ./...`, which traverses all modules listed in `go.work`.
 
+### Frontend Tests
+To run the React unit tests install dependencies first:
+
+```bash
+npm ci --prefix internal/ui
+npm test --prefix internal/ui
+```
+
+### Logging
+Set the log level at runtime with the `-loglevel` flag (e.g. `-loglevel debug`).
+
 ## Key Features
 
 - **React + Material UI Interface**: UI built with React components styled using Material UI.

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -4,30 +4,53 @@ import (
 	"baristeuer/internal/data"
 	"baristeuer/internal/taxlogic"
 	"fmt"
-	"log"
+	"log/slog"
 	"os"
+	"strings"
 )
 
 // DataService provides application methods used by the UI.
 type DataService struct {
 	store  *data.Store
-	logger *log.Logger
+	logger *slog.Logger
+	taxCfg taxlogic.TaxConfig
 }
 
 // NewDataService creates a new service with the given datastore location.
 func NewDataService(dsn string) (*DataService, error) {
+	return NewDataServiceWithConfig(dsn, taxlogic.DefaultConfig2025())
+}
+
+// NewDataServiceWithConfig creates a new service using the provided tax configuration.
+func NewDataServiceWithConfig(dsn string, cfg taxlogic.TaxConfig) (*DataService, error) {
 	s, err := data.NewStore(dsn)
 	if err != nil {
 		return nil, fmt.Errorf("create store: %w", err)
 	}
-	l := log.New(os.Stdout, "DataService: ", log.LstdFlags)
-	return &DataService{store: s, logger: l}, nil
+	l := newLogger()
+	return &DataService{store: s, logger: l, taxCfg: cfg}, nil
 }
 
 // NewDataServiceFromStore wraps an existing store.
-func NewDataServiceFromStore(store *data.Store) *DataService {
-	l := log.New(os.Stdout, "DataService: ", log.LstdFlags)
-	return &DataService{store: store, logger: l}
+func NewDataServiceFromStore(store *data.Store, cfg taxlogic.TaxConfig) *DataService {
+	l := newLogger()
+	return &DataService{store: store, logger: l, taxCfg: cfg}
+}
+
+func newLogger() *slog.Logger {
+	level := slog.LevelInfo
+	if lv := strings.ToLower(os.Getenv("LOG_LEVEL")); lv != "" {
+		switch lv {
+		case "debug":
+			level = slog.LevelDebug
+		case "warn":
+			level = slog.LevelWarn
+		case "error":
+			level = slog.LevelError
+		}
+	}
+	handler := slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: level})
+	return slog.New(handler)
 }
 
 // CreateProject creates a project by name.
@@ -36,27 +59,27 @@ func (ds *DataService) CreateProject(name string) (*data.Project, error) {
 	if err := ds.store.CreateProject(p); err != nil {
 		return nil, fmt.Errorf("create project: %w", err)
 	}
-	ds.logger.Printf("Created project %d", p.ID)
+	ds.logger.Info("created project", "id", p.ID)
 	return p, nil
+}
+
+// ListProjects returns all projects.
+func (ds *DataService) ListProjects() ([]data.Project, error) {
+	projects, err := ds.store.ListProjects()
+	if err != nil {
+		return nil, fmt.Errorf("list projects: %w", err)
+	}
+	ds.logger.Info("listed projects", "count", len(projects))
+	return projects, nil
 }
 
 // ListIncomes returns all incomes for the given project.
 func (ds *DataService) ListIncomes(projectID int64) ([]data.Income, error) {
-	rows, err := ds.store.DB.Query(`SELECT id, project_id, source, amount FROM incomes WHERE project_id=?`, projectID)
+	incomes, err := ds.store.ListIncomes(projectID)
 	if err != nil {
-		return nil, fmt.Errorf("query incomes: %w", err)
+		return nil, fmt.Errorf("list incomes: %w", err)
 	}
-	defer rows.Close()
-
-	var incomes []data.Income
-	for rows.Next() {
-		var i data.Income
-		if err := rows.Scan(&i.ID, &i.ProjectID, &i.Source, &i.Amount); err != nil {
-			return nil, fmt.Errorf("scan income: %w", err)
-		}
-		incomes = append(incomes, i)
-	}
-	ds.logger.Printf("Listed %d incomes for project %d", len(incomes), projectID)
+	ds.logger.Info("listed incomes", "project", projectID, "count", len(incomes))
 	return incomes, nil
 }
 
@@ -66,7 +89,7 @@ func (ds *DataService) AddIncome(projectID int64, source string, amount float64)
 	if err := ds.store.CreateIncome(i); err != nil {
 		return nil, fmt.Errorf("create income: %w", err)
 	}
-	ds.logger.Printf("Added income %.2f to project %d", amount, projectID)
+	ds.logger.Info("added income", "project", projectID, "amount", amount)
 	return i, nil
 }
 
@@ -76,7 +99,7 @@ func (ds *DataService) UpdateIncome(id int64, projectID int64, source string, am
 	if err := ds.store.UpdateIncome(i); err != nil {
 		return fmt.Errorf("update income: %w", err)
 	}
-	ds.logger.Printf("Updated income %d", id)
+	ds.logger.Info("updated income", "id", id)
 	return nil
 }
 
@@ -85,7 +108,7 @@ func (ds *DataService) DeleteIncome(id int64) error {
 	if err := ds.store.DeleteIncome(id); err != nil {
 		return fmt.Errorf("delete income: %w", err)
 	}
-	ds.logger.Printf("Deleted income %d", id)
+	ds.logger.Info("deleted income", "id", id)
 	return nil
 }
 
@@ -95,7 +118,7 @@ func (ds *DataService) AddExpense(projectID int64, category string, amount float
 	if err := ds.store.CreateExpense(e); err != nil {
 		return nil, fmt.Errorf("create expense: %w", err)
 	}
-	ds.logger.Printf("Added expense %.2f to project %d", amount, projectID)
+	ds.logger.Info("added expense", "project", projectID, "amount", amount)
 	return e, nil
 }
 
@@ -105,7 +128,7 @@ func (ds *DataService) UpdateExpense(id int64, projectID int64, category string,
 	if err := ds.store.UpdateExpense(e); err != nil {
 		return fmt.Errorf("update expense: %w", err)
 	}
-	ds.logger.Printf("Updated expense %d", id)
+	ds.logger.Info("updated expense", "id", id)
 	return nil
 }
 
@@ -114,27 +137,17 @@ func (ds *DataService) DeleteExpense(id int64) error {
 	if err := ds.store.DeleteExpense(id); err != nil {
 		return fmt.Errorf("delete expense: %w", err)
 	}
-	ds.logger.Printf("Deleted expense %d", id)
+	ds.logger.Info("deleted expense", "id", id)
 	return nil
 }
 
 // ListExpenses returns all expenses for the given project.
 func (ds *DataService) ListExpenses(projectID int64) ([]data.Expense, error) {
-	rows, err := ds.store.DB.Query(`SELECT id, project_id, category, amount FROM expenses WHERE project_id=?`, projectID)
+	expenses, err := ds.store.ListExpenses(projectID)
 	if err != nil {
-		return nil, fmt.Errorf("query expenses: %w", err)
+		return nil, fmt.Errorf("list expenses: %w", err)
 	}
-	defer rows.Close()
-
-	var expenses []data.Expense
-	for rows.Next() {
-		var e data.Expense
-		if err := rows.Scan(&e.ID, &e.ProjectID, &e.Category, &e.Amount); err != nil {
-			return nil, fmt.Errorf("scan expense: %w", err)
-		}
-		expenses = append(expenses, e)
-	}
-	ds.logger.Printf("Listed %d expenses for project %d", len(expenses), projectID)
+	ds.logger.Info("listed expenses", "project", projectID, "count", len(expenses))
 	return expenses, nil
 }
 
@@ -144,7 +157,7 @@ func (ds *DataService) AddMember(name, email, joinDate string) (*data.Member, er
 	if err := ds.store.CreateMember(m); err != nil {
 		return nil, fmt.Errorf("create member: %w", err)
 	}
-	ds.logger.Printf("Added member %s", name)
+	ds.logger.Info("added member", "name", name)
 	return m, nil
 }
 
@@ -154,7 +167,7 @@ func (ds *DataService) ListMembers() ([]data.Member, error) {
 	if err != nil {
 		return nil, fmt.Errorf("list members: %w", err)
 	}
-	ds.logger.Printf("Listed %d members", len(members))
+	ds.logger.Info("listed members", "count", len(members))
 	return members, nil
 }
 
@@ -168,8 +181,8 @@ func (ds *DataService) CalculateProjectTaxes(projectID int64) (taxlogic.TaxResul
 	if err != nil {
 		return taxlogic.TaxResult{}, fmt.Errorf("sum expense: %w", err)
 	}
-	result := taxlogic.CalculateTaxes(revenue, expenses)
-	ds.logger.Printf("Calculated taxes for project %d: %.2f EUR", projectID, result.TotalTax)
+	result := taxlogic.CalculateTaxesWithConfig(revenue, expenses, ds.taxCfg)
+	ds.logger.Info("calculated taxes", "project", projectID, "total", result.TotalTax)
 	return result, nil
 }
 

--- a/internal/service/service_test.go
+++ b/internal/service/service_test.go
@@ -2,7 +2,7 @@ package service
 
 import (
 	"bytes"
-	"log"
+	"log/slog"
 	"strings"
 	"testing"
 )
@@ -189,6 +189,29 @@ func TestDataService_MemberOperations(t *testing.T) {
 	}
 }
 
+func TestDataService_ListProjects(t *testing.T) {
+	ds, err := NewDataService(":memory:")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ds.Close()
+
+	if _, err := ds.CreateProject("P1"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := ds.CreateProject("P2"); err != nil {
+		t.Fatal(err)
+	}
+
+	list, err := ds.ListProjects()
+	if err != nil {
+		t.Fatalf("ListProjects returned error: %v", err)
+	}
+	if len(list) != 2 {
+		t.Fatalf("expected 2 projects, got %d", len(list))
+	}
+}
+
 func TestDataService_AddIncome_LogOutput(t *testing.T) {
 	ds, err := NewDataService(":memory:")
 	if err != nil {
@@ -197,13 +220,13 @@ func TestDataService_AddIncome_LogOutput(t *testing.T) {
 	defer ds.Close()
 
 	var buf bytes.Buffer
-	ds.logger = log.New(&buf, "", 0)
+	ds.logger = slog.New(slog.NewTextHandler(&buf, nil))
 
 	proj, _ := ds.CreateProject("Log Project")
 	if _, err := ds.AddIncome(proj.ID, "donation", 5); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if !strings.Contains(buf.String(), "Added income") {
+	if !strings.Contains(buf.String(), "added income") {
 		t.Fatalf("log output missing: %s", buf.String())
 	}
 }

--- a/internal/taxlogic/tax_logic_test.go
+++ b/internal/taxlogic/tax_logic_test.go
@@ -5,6 +5,18 @@ import (
 	"testing"
 )
 
+func TestConfigForYear(t *testing.T) {
+	cfg2025 := ConfigForYear(2025)
+	def := DefaultConfig2025()
+	if cfg2025 != def {
+		t.Fatalf("2025 config mismatch")
+	}
+	cfgOther := ConfigForYear(2030)
+	if cfgOther != def {
+		t.Fatalf("default config expected for unknown year")
+	}
+}
+
 // Helper function to compare floats with a tolerance.
 func floatEquals(a, b float64) bool {
 	const tolerance = 1e-9
@@ -12,6 +24,7 @@ func floatEquals(a, b float64) bool {
 }
 
 func TestCalculateTaxes(t *testing.T) {
+	cfg := DefaultConfig2025()
 	testCases := []struct {
 		name     string
 		revenue  float64
@@ -31,8 +44,8 @@ func TestCalculateTaxes(t *testing.T) {
 				CorporateTax:          0,
 				SolidaritySurcharge:   0,
 				TotalTax:              0,
-				RevenueExemptionLimit: RevenueExemptionLimit,
-				ProfitAllowance:       ProfitAllowance,
+				RevenueExemptionLimit: cfg.RevenueExemptionLimit,
+				ProfitAllowance:       cfg.ProfitAllowance,
 			},
 		},
 		{
@@ -48,8 +61,8 @@ func TestCalculateTaxes(t *testing.T) {
 				CorporateTax:          3750.00,  // 25000 * 0.15
 				SolidaritySurcharge:   206.25,   // 3750 * 0.055
 				TotalTax:              3956.25,  // 3750 + 206.25
-				RevenueExemptionLimit: RevenueExemptionLimit,
-				ProfitAllowance:       ProfitAllowance,
+				RevenueExemptionLimit: cfg.RevenueExemptionLimit,
+				ProfitAllowance:       cfg.ProfitAllowance,
 			},
 		},
 		{
@@ -65,8 +78,8 @@ func TestCalculateTaxes(t *testing.T) {
 				CorporateTax:          0,
 				SolidaritySurcharge:   0,
 				TotalTax:              0,
-				RevenueExemptionLimit: RevenueExemptionLimit,
-				ProfitAllowance:       ProfitAllowance,
+				RevenueExemptionLimit: cfg.RevenueExemptionLimit,
+				ProfitAllowance:       cfg.ProfitAllowance,
 			},
 		},
 		{
@@ -82,8 +95,8 @@ func TestCalculateTaxes(t *testing.T) {
 				CorporateTax:          0,
 				SolidaritySurcharge:   0,
 				TotalTax:              0,
-				RevenueExemptionLimit: RevenueExemptionLimit,
-				ProfitAllowance:       ProfitAllowance,
+				RevenueExemptionLimit: cfg.RevenueExemptionLimit,
+				ProfitAllowance:       cfg.ProfitAllowance,
 			},
 		},
 		{
@@ -99,8 +112,8 @@ func TestCalculateTaxes(t *testing.T) {
 				CorporateTax:          0,
 				SolidaritySurcharge:   0,
 				TotalTax:              0,
-				RevenueExemptionLimit: RevenueExemptionLimit,
-				ProfitAllowance:       ProfitAllowance,
+				RevenueExemptionLimit: cfg.RevenueExemptionLimit,
+				ProfitAllowance:       cfg.ProfitAllowance,
 			},
 		},
 		{
@@ -116,8 +129,8 @@ func TestCalculateTaxes(t *testing.T) {
 				CorporateTax:          0,
 				SolidaritySurcharge:   0,
 				TotalTax:              0,
-				RevenueExemptionLimit: RevenueExemptionLimit,
-				ProfitAllowance:       ProfitAllowance,
+				RevenueExemptionLimit: cfg.RevenueExemptionLimit,
+				ProfitAllowance:       cfg.ProfitAllowance,
 			},
 		},
 	}

--- a/internal/ui/src/App.jsx
+++ b/internal/ui/src/App.jsx
@@ -1,90 +1,38 @@
 import { useState, useEffect } from "react";
 import { ThemeProvider, createTheme } from "@mui/material/styles";
-import {
-  CssBaseline,
-  Container,
-  Typography,
-  Button,
-  TextField,
-  Table,
-  TableBody,
-  TableCell,
-  TableHead,
-  TableRow,
-  Paper,
-  Switch,
-  FormControlLabel,
-  Box,
-  AppBar,
-  Toolbar,
-  Tabs,
-  Tab,
-  Grid,
-  Card,
-  CardContent,
-} from "@mui/material";
-import {
-  AddExpense,
-  ListExpenses,
-  AddIncome,
-  ListIncomes,
-  UpdateIncome,
-  DeleteIncome,
-  UpdateExpense,
-  DeleteExpense,
-  CalculateProjectTaxes,
-} from "./wailsjs/go/service/DataService";
-import {
-  GenerateReport,
-  GenerateKSt1,
-  GenerateAnlageGem,
-  GenerateAnlageGK,
-  GenerateKSt1F,
-  GenerateAnlageSport,
-  GenerateAllForms,
-} from "./wailsjs/go/pdf/Generator";
+import { CssBaseline, Container, FormControlLabel, Switch, AppBar, Toolbar, Typography, Tabs, Tab, Paper } from "@mui/material";
+import { ListExpenses, ListIncomes, AddIncome, UpdateIncome, DeleteIncome, AddExpense, UpdateExpense, DeleteExpense } from "./wailsjs/go/service/DataService";
+import MemberPanel from "./components/MemberPanel";
+import IncomeForm from "./components/IncomeForm";
+import IncomeTable from "./components/IncomeTable";
+import ExpenseForm from "./components/ExpenseForm";
+import ExpenseTable from "./components/ExpenseTable";
+import TaxPanel from "./components/TaxPanel";
+import FormsPanel from "./components/FormsPanel";
 
 export default function App() {
   const [incomes, setIncomes] = useState([]);
   const [expenses, setExpenses] = useState([]);
-  const [source, setSource] = useState("");
-  const [description, setDescription] = useState("");
-  const [amount, setAmount] = useState("");
-  const [error, setError] = useState("");
-  const [taxes, setTaxes] = useState(null);
+  const [editIncome, setEditIncome] = useState(null);
+  const [editExpense, setEditExpense] = useState(null);
   const [darkMode, setDarkMode] = useState(false);
   const [tab, setTab] = useState(0);
-  const [editIncomeId, setEditIncomeId] = useState(null);
-  const [editExpenseId, setEditExpenseId] = useState(null);
 
   const theme = createTheme({
     palette: {
       mode: darkMode ? "dark" : "light",
-      primary: {
-        main: "#1976d2",
-      },
-      secondary: {
-        main: "#9c27b0",
-      },
+      primary: { main: "#1976d2" },
+      secondary: { main: "#9c27b0" },
     },
   });
 
   const fetchExpenses = async () => {
-    try {
-      const list = await ListExpenses(1);
-      setExpenses(list || []);
-    } catch (err) {
-      setError(err.message || "Fehler beim Abrufen der Ausgaben");
-    }
+    const list = await ListExpenses(1);
+    setExpenses(list || []);
   };
-
   const fetchIncomes = async () => {
-    try {
-      const list = await ListIncomes(1);
-      setIncomes(list || []);
-    } catch (err) {
-      setError(err.message || "Fehler beim Abrufen der Einnahmen");
-    }
+    const list = await ListIncomes(1);
+    setIncomes(list || []);
   };
 
   useEffect(() => {
@@ -92,76 +40,33 @@ export default function App() {
     fetchIncomes();
   }, []);
 
-  const handleAddExpense = async (e) => {
-    e.preventDefault();
-    const value = parseFloat(amount);
-    if (!description || !amount) {
-      setError("Beschreibung und Betrag erforderlich");
-      return;
-    }
-    if (Number.isNaN(value) || value <= 0) {
-      setError("Betrag muss eine positive Zahl sein");
-      return;
-    }
+  const submitIncome = async (source, amount, setError) => {
     try {
-      if (editExpenseId !== null) {
-        await UpdateExpense(editExpenseId, 1, description, value);
-        setEditExpenseId(null);
+      if (editIncome) {
+        await UpdateIncome(editIncome.id, 1, source, amount);
+        setEditIncome(null);
       } else {
-        await AddExpense(1, description, value);
+        await AddIncome(1, source, amount);
       }
-      setDescription("");
-      setAmount("");
       setError("");
-      await fetchExpenses();
+      fetchIncomes();
     } catch (err) {
       setError(err.message || "Fehler beim Hinzufügen");
     }
   };
 
-  const handleAddIncome = async (e) => {
-    e.preventDefault();
-    const value = parseFloat(amount);
-    if (!source || !amount) {
-      setError("Quelle und Betrag erforderlich");
-      return;
-    }
-    if (Number.isNaN(value) || value <= 0) {
-      setError("Betrag muss eine positive Zahl sein");
-      return;
-    }
+  const submitExpense = async (desc, amount, setError) => {
     try {
-      if (editIncomeId !== null) {
-        await UpdateIncome(editIncomeId, 1, source, value);
-        setEditIncomeId(null);
+      if (editExpense) {
+        await UpdateExpense(editExpense.id, 1, desc, amount);
+        setEditExpense(null);
       } else {
-        await AddIncome(1, source, value);
+        await AddExpense(1, desc, amount);
       }
-      setSource("");
-      setAmount("");
       setError("");
-      await fetchIncomes();
+      fetchExpenses();
     } catch (err) {
       setError(err.message || "Fehler beim Hinzufügen");
-    }
-  };
-
-  const handleGenerate = async (fn) => {
-    try {
-      await fn(1);
-      setError("");
-    } catch (err) {
-      setError(err.message || "Fehler beim Erzeugen");
-    }
-  };
-
-  const handleCalculateTaxes = async () => {
-    try {
-      const result = await CalculateProjectTaxes(1);
-      setTaxes(result);
-      setError("");
-    } catch (err) {
-      setError(err.message || "Fehler bei Berechnung");
     }
   };
 
@@ -174,25 +79,14 @@ export default function App() {
             Baristeuer
           </Typography>
           <FormControlLabel
-            control={
-              <Switch
-                checked={darkMode}
-                onChange={() => setDarkMode(!darkMode)}
-                color="default"
-              />
-            }
+            control={<Switch checked={darkMode} onChange={() => setDarkMode(!darkMode)} color="default" />}
             label={darkMode ? "Dunkel" : "Hell"}
           />
         </Toolbar>
-        <Tabs
-          value={tab}
-          onChange={(_, v) => setTab(v)}
-          textColor="inherit"
-          indicatorColor="secondary"
-          centered
-        >
+        <Tabs value={tab} onChange={(_, v) => setTab(v)} textColor="inherit" indicatorColor="secondary" centered>
           <Tab label="Einnahmen" />
           <Tab label="Ausgaben" />
+          <Tab label="Mitglieder" />
           <Tab label="Formulare" />
           <Tab label="Steuern" />
         </Tabs>
@@ -204,85 +98,17 @@ export default function App() {
               <Typography variant="h6" component="h2" gutterBottom>
                 Neue Einnahme
               </Typography>
-              <Box
-                component="form"
-                onSubmit={handleAddIncome}
-                display="flex"
-                gap={2}
-                flexWrap="wrap"
-              >
-                <TextField
-                  label="Quelle"
-                  value={source}
-                  onChange={(e) => setSource(e.target.value)}
-                  fullWidth
-                />
-                <TextField
-                  label="Betrag (€)"
-                  type="number"
-                  value={amount}
-                  onChange={(e) => setAmount(e.target.value)}
-                />
-                <Button type="submit" variant="contained">
-                  Hinzufügen
-                </Button>
-              </Box>
-              {error && (
-                <Typography color="error" sx={{ mt: 2 }}>
-                  {error}
-                </Typography>
-              )}
+              <IncomeForm onSubmit={submitIncome} editItem={editIncome} />
             </Paper>
             <Paper>
-              <Table>
-                <TableHead>
-                  <TableRow>
-                    <TableCell>Quelle</TableCell>
-                    <TableCell align="right">Betrag (€)</TableCell>
-                    <TableCell>Aktionen</TableCell>
-                  </TableRow>
-                </TableHead>
-                <TableBody>
-                  {incomes.length > 0 ? (
-                    incomes.map((i, idx) => (
-                      <TableRow key={idx} hover>
-                        <TableCell>{i.source}</TableCell>
-                        <TableCell align="right">
-                          {i.amount.toFixed(2)}
-                        </TableCell>
-                        <TableCell>
-                          <Button
-                            size="small"
-                            onClick={() => {
-                              setSource(i.source);
-                              setAmount(String(i.amount));
-                              setEditIncomeId(i.id);
-                            }}
-                          >
-                            Bearbeiten
-                          </Button>
-                          <Button
-                            size="small"
-                            color="error"
-                            onClick={async () => {
-                              await DeleteIncome(i.id);
-                              fetchIncomes();
-                            }}
-                          >
-                            Löschen
-                          </Button>
-                        </TableCell>
-                      </TableRow>
-                    ))
-                  ) : (
-                    <TableRow>
-                      <TableCell colSpan={3} align="center">
-                        Keine Einnahmen vorhanden
-                      </TableCell>
-                    </TableRow>
-                  )}
-                </TableBody>
-              </Table>
+              <IncomeTable
+                incomes={incomes}
+                onEdit={(i) => setEditIncome(i)}
+                onDelete={async (id) => {
+                  await DeleteIncome(id);
+                  fetchIncomes();
+                }}
+              />
             </Paper>
           </>
         )}
@@ -292,194 +118,25 @@ export default function App() {
               <Typography variant="h6" component="h2" gutterBottom>
                 Neue Ausgabe
               </Typography>
-              <Box
-                component="form"
-                onSubmit={handleAddExpense}
-                display="flex"
-                gap={2}
-                flexWrap="wrap"
-              >
-                <TextField
-                  label="Beschreibung"
-                  value={description}
-                  onChange={(e) => setDescription(e.target.value)}
-                  fullWidth
-                />
-                <TextField
-                  label="Betrag (€)"
-                  type="number"
-                  value={amount}
-                  onChange={(e) => setAmount(e.target.value)}
-                />
-                <Button type="submit" variant="contained">
-                  Hinzufügen
-                </Button>
-              </Box>
-              {error && (
-                <Typography color="error" sx={{ mt: 2 }}>
-                  {error}
-                </Typography>
-              )}
+              <ExpenseForm onSubmit={submitExpense} editItem={editExpense} />
             </Paper>
             <Paper>
-              <Table>
-                <TableHead>
-                  <TableRow>
-                    <TableCell>Beschreibung</TableCell>
-                    <TableCell align="right">Betrag (€)</TableCell>
-                    <TableCell>Aktionen</TableCell>
-                  </TableRow>
-                </TableHead>
-                <TableBody>
-                  {expenses.length > 0 ? (
-                    expenses.map((e, idx) => (
-                      <TableRow key={idx} hover>
-                        <TableCell>{e.description}</TableCell>
-                        <TableCell align="right">
-                          {e.amount.toFixed(2)}
-                        </TableCell>
-                        <TableCell>
-                          <Button
-                            size="small"
-                            onClick={() => {
-                              setDescription(e.description);
-                              setAmount(String(e.amount));
-                              setEditExpenseId(e.id);
-                            }}
-                          >
-                            Bearbeiten
-                          </Button>
-                          <Button
-                            size="small"
-                            color="error"
-                            onClick={async () => {
-                              await DeleteExpense(e.id);
-                              fetchExpenses();
-                            }}
-                          >
-                            Löschen
-                          </Button>
-                        </TableCell>
-                      </TableRow>
-                    ))
-                  ) : (
-                    <TableRow>
-                      <TableCell colSpan={3} align="center">
-                        Keine Ausgaben vorhanden
-                      </TableCell>
-                    </TableRow>
-                  )}
-                </TableBody>
-              </Table>
+              <ExpenseTable
+                expenses={expenses}
+                onEdit={(e) => setEditExpense(e)}
+                onDelete={async (id) => {
+                  await DeleteExpense(id);
+                  fetchExpenses();
+                }}
+              />
             </Paper>
           </>
         )}
-        {tab === 2 && (
-          <Grid container spacing={2}>
-            <Grid item xs={12}>
-              <Button
-                fullWidth
-                variant="contained"
-                color="secondary"
-                onClick={() => handleGenerate(GenerateAllForms)}
-              >
-                Alle Formulare erstellen
-              </Button>
-            </Grid>
-            <Grid item xs={12} sm={6}>
-              <Card>
-                <CardContent>
-                  <Typography gutterBottom>KSt 1</Typography>
-                  <Button
-                    variant="outlined"
-                    onClick={() => handleGenerate(GenerateKSt1)}
-                  >
-                    Erstellen
-                  </Button>
-                </CardContent>
-              </Card>
-            </Grid>
-            <Grid item xs={12} sm={6}>
-              <Card>
-                <CardContent>
-                  <Typography gutterBottom>Anlage Gem</Typography>
-                  <Button
-                    variant="outlined"
-                    onClick={() => handleGenerate(GenerateAnlageGem)}
-                  >
-                    Erstellen
-                  </Button>
-                </CardContent>
-              </Card>
-            </Grid>
-            <Grid item xs={12} sm={6}>
-              <Card>
-                <CardContent>
-                  <Typography gutterBottom>Anlage GK</Typography>
-                  <Button
-                    variant="outlined"
-                    onClick={() => handleGenerate(GenerateAnlageGK)}
-                  >
-                    Erstellen
-                  </Button>
-                </CardContent>
-              </Card>
-            </Grid>
-            <Grid item xs={12} sm={6}>
-              <Card>
-                <CardContent>
-                  <Typography gutterBottom>KSt 1F</Typography>
-                  <Button
-                    variant="outlined"
-                    onClick={() => handleGenerate(GenerateKSt1F)}
-                  >
-                    Erstellen
-                  </Button>
-                </CardContent>
-              </Card>
-            </Grid>
-            <Grid item xs={12} sm={6}>
-              <Card>
-                <CardContent>
-                  <Typography gutterBottom>Anlage Sport</Typography>
-                  <Button
-                    variant="outlined"
-                    onClick={() => handleGenerate(GenerateAnlageSport)}
-                  >
-                    Erstellen
-                  </Button>
-                </CardContent>
-              </Card>
-            </Grid>
-          </Grid>
-        )}
-        {tab === 3 && (
+        {tab === 2 && <MemberPanel />}
+        {tab === 3 && <FormsPanel />}
+        {tab === 4 && (
           <Paper sx={{ p: 3 }}>
-            <Button
-              variant="contained"
-              color="secondary"
-              onClick={handleCalculateTaxes}
-            >
-              Steuern berechnen
-            </Button>
-            {taxes && (
-              <Box sx={{ mt: 2 }}>
-                <Typography>Einnahmen: {taxes.revenue.toFixed(2)} €</Typography>
-                <Typography>Ausgaben: {taxes.expenses.toFixed(2)} €</Typography>
-                <Typography>
-                  Steuerpflichtiges Einkommen: {taxes.taxableIncome.toFixed(2)}{" "}
-                  €
-                </Typography>
-                <Typography>
-                  Gesamtsteuer: {taxes.totalTax.toFixed(2)} €
-                </Typography>
-              </Box>
-            )}
-            {error && (
-              <Typography color="error" sx={{ mt: 2 }}>
-                {error}
-              </Typography>
-            )}
+            <TaxPanel />
           </Paper>
         )}
       </Container>

--- a/internal/ui/src/App.test.jsx
+++ b/internal/ui/src/App.test.jsx
@@ -14,6 +14,8 @@ vi.mock('./wailsjs/go/service/DataService', () => ({
   DeleteIncome: vi.fn(),
   ListIncomes: vi.fn(),
   CalculateProjectTaxes: vi.fn(),
+  AddMember: vi.fn(),
+  ListMembers: vi.fn(),
 }), { virtual: true });
 
 // import the mocked functions for easier access
@@ -27,10 +29,13 @@ import {
   DeleteIncome,
   ListIncomes,
   CalculateProjectTaxes,
+  AddMember,
+  ListMembers,
 } from './wailsjs/go/service/DataService';
 
 beforeEach(() => {
   vi.clearAllMocks();
+  ListMembers.mockResolvedValue([]);
 });
 
 test('renders app heading', async () => {
@@ -179,4 +184,22 @@ test('shows tax calculation result', async () => {
   expect(screen.getByText('Ausgaben: 20.00 \u20AC')).toBeInTheDocument();
   expect(screen.getByText('Steuerpflichtiges Einkommen: 80.00 \u20AC')).toBeInTheDocument();
   expect(screen.getByText('Gesamtsteuer: 10.00 \u20AC')).toBeInTheDocument();
+});
+
+test('adds a new member', async () => {
+  ListExpenses.mockResolvedValueOnce([]);
+  ListIncomes.mockResolvedValueOnce([]);
+  ListMembers.mockResolvedValueOnce([]).mockResolvedValueOnce([{ id: 1, name: 'Bob', email: 'b@example.com', join_date: '2024-01-01' }]);
+  AddMember.mockResolvedValueOnce();
+  render(<App />);
+  await screen.findByRole('heading', { name: /Baristeuer/i });
+
+  fireEvent.click(screen.getByRole('tab', { name: /Mitglieder/i }));
+  fireEvent.change(screen.getByLabelText(/Name/i), { target: { value: 'Bob' } });
+  fireEvent.change(screen.getByLabelText(/Email/i), { target: { value: 'b@example.com' } });
+  fireEvent.change(screen.getByLabelText(/Beitrittsdatum/i), { target: { value: '2024-01-01' } });
+  fireEvent.click(screen.getByRole('button', { name: /Hinzufügen/i }));
+
+  await waitFor(() => expect(AddMember).toHaveBeenCalled());
+  expect(await screen.findByText('Bob')).toBeInTheDocument();
 });

--- a/internal/ui/src/components/ExpenseForm.jsx
+++ b/internal/ui/src/components/ExpenseForm.jsx
@@ -1,0 +1,41 @@
+import { useState } from "react";
+import { Box, TextField, Button, Typography } from "@mui/material";
+
+export default function ExpenseForm({ onSubmit, editItem }) {
+  const [description, setDescription] = useState(editItem ? editItem.description : "");
+  const [amount, setAmount] = useState(editItem ? String(editItem.amount) : "");
+  const [error, setError] = useState("");
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    const value = parseFloat(amount);
+    if (!description || !amount) {
+      setError("Beschreibung und Betrag erforderlich");
+      return;
+    }
+    if (Number.isNaN(value) || value <= 0) {
+      setError("Betrag muss eine positive Zahl sein");
+      return;
+    }
+    await onSubmit(description, value, setError);
+    if (!editItem) {
+      setDescription("");
+      setAmount("");
+    }
+  };
+
+  return (
+    <Box component="form" onSubmit={handleSubmit} display="flex" gap={2} flexWrap="wrap">
+      <TextField label="Beschreibung" value={description} onChange={(e) => setDescription(e.target.value)} fullWidth />
+      <TextField label="Betrag (€)" type="number" value={amount} onChange={(e) => setAmount(e.target.value)} />
+      <Button type="submit" variant="contained">
+        Hinzufügen
+      </Button>
+      {error && (
+        <Typography color="error" sx={{ mt: 2 }}>
+          {error}
+        </Typography>
+      )}
+    </Box>
+  );
+}

--- a/internal/ui/src/components/ExpenseTable.jsx
+++ b/internal/ui/src/components/ExpenseTable.jsx
@@ -1,0 +1,39 @@
+import { Table, TableHead, TableBody, TableRow, TableCell, Button } from "@mui/material";
+
+export default function ExpenseTable({ expenses, onEdit, onDelete }) {
+  return (
+    <Table>
+      <TableHead>
+        <TableRow>
+          <TableCell>Beschreibung</TableCell>
+          <TableCell align="right">Betrag (€)</TableCell>
+          <TableCell>Aktionen</TableCell>
+        </TableRow>
+      </TableHead>
+      <TableBody>
+        {expenses.length > 0 ? (
+          expenses.map((e) => (
+            <TableRow key={e.id} hover>
+              <TableCell>{e.description}</TableCell>
+              <TableCell align="right">{e.amount.toFixed(2)}</TableCell>
+              <TableCell>
+                <Button size="small" onClick={() => onEdit(e)}>
+                  Bearbeiten
+                </Button>
+                <Button size="small" color="error" onClick={() => onDelete(e.id)}>
+                  Löschen
+                </Button>
+              </TableCell>
+            </TableRow>
+          ))
+        ) : (
+          <TableRow>
+            <TableCell colSpan={3} align="center">
+              Keine Ausgaben vorhanden
+            </TableCell>
+          </TableRow>
+        )}
+      </TableBody>
+    </Table>
+  );
+}

--- a/internal/ui/src/components/FormsPanel.jsx
+++ b/internal/ui/src/components/FormsPanel.jsx
@@ -1,0 +1,126 @@
+import {
+  Grid,
+  Card,
+  CardContent,
+  Typography,
+  Button,
+  Alert,
+} from "@mui/material";
+import { useState } from "react";
+import {
+  GenerateAllForms,
+  GenerateAnlageGem,
+  GenerateAnlageGK,
+  GenerateAnlageSport,
+  GenerateKSt1,
+  GenerateKSt1F,
+  GenerateFormsArchive,
+} from "../wailsjs/go/pdf/Generator";
+
+export default function FormsPanel() {
+  const [error, setError] = useState("");
+
+  const handleGenerate = async (fn) => {
+    try {
+      await fn(1);
+      setError("");
+    } catch (err) {
+      setError(err.message || "Fehler beim Erstellen");
+    }
+  };
+
+  return (
+    <Grid container spacing={2}>
+      {error && (
+        <Grid item xs={12}>
+          <Alert severity="error">{error}</Alert>
+        </Grid>
+      )}
+      <Grid item xs={12}>
+        <Button
+          fullWidth
+          variant="contained"
+          color="secondary"
+          onClick={() => handleGenerate(GenerateAllForms)}
+        >
+          Alle Formulare erstellen
+        </Button>
+      </Grid>
+      <Grid item xs={12}>
+        <Button
+          fullWidth
+          variant="contained"
+          color="secondary"
+          onClick={() => handleGenerate(GenerateFormsArchive)}
+        >
+          Formulare als ZIP
+        </Button>
+      </Grid>
+      <Grid item xs={12} sm={6}>
+        <Card>
+          <CardContent>
+            <Typography gutterBottom>KSt 1</Typography>
+            <Button
+              variant="outlined"
+              onClick={() => handleGenerate(GenerateKSt1)}
+            >
+              Erstellen
+            </Button>
+          </CardContent>
+        </Card>
+      </Grid>
+      <Grid item xs={12} sm={6}>
+        <Card>
+          <CardContent>
+            <Typography gutterBottom>Anlage Gem</Typography>
+            <Button
+              variant="outlined"
+              onClick={() => handleGenerate(GenerateAnlageGem)}
+            >
+              Erstellen
+            </Button>
+          </CardContent>
+        </Card>
+      </Grid>
+      <Grid item xs={12} sm={6}>
+        <Card>
+          <CardContent>
+            <Typography gutterBottom>Anlage GK</Typography>
+            <Button
+              variant="outlined"
+              onClick={() => handleGenerate(GenerateAnlageGK)}
+            >
+              Erstellen
+            </Button>
+          </CardContent>
+        </Card>
+      </Grid>
+      <Grid item xs={12} sm={6}>
+        <Card>
+          <CardContent>
+            <Typography gutterBottom>KSt 1F</Typography>
+            <Button
+              variant="outlined"
+              onClick={() => handleGenerate(GenerateKSt1F)}
+            >
+              Erstellen
+            </Button>
+          </CardContent>
+        </Card>
+      </Grid>
+      <Grid item xs={12} sm={6}>
+        <Card>
+          <CardContent>
+            <Typography gutterBottom>Anlage Sport</Typography>
+            <Button
+              variant="outlined"
+              onClick={() => handleGenerate(GenerateAnlageSport)}
+            >
+              Erstellen
+            </Button>
+          </CardContent>
+        </Card>
+      </Grid>
+    </Grid>
+  );
+}

--- a/internal/ui/src/components/IncomeForm.jsx
+++ b/internal/ui/src/components/IncomeForm.jsx
@@ -1,0 +1,41 @@
+import { useState } from "react";
+import { Box, TextField, Button, Typography } from "@mui/material";
+
+export default function IncomeForm({ onSubmit, editItem }) {
+  const [source, setSource] = useState(editItem ? editItem.source : "");
+  const [amount, setAmount] = useState(editItem ? String(editItem.amount) : "");
+  const [error, setError] = useState("");
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    const value = parseFloat(amount);
+    if (!source || !amount) {
+      setError("Quelle und Betrag erforderlich");
+      return;
+    }
+    if (Number.isNaN(value) || value <= 0) {
+      setError("Betrag muss eine positive Zahl sein");
+      return;
+    }
+    await onSubmit(source, value, setError);
+    if (!editItem) {
+      setSource("");
+      setAmount("");
+    }
+  };
+
+  return (
+    <Box component="form" onSubmit={handleSubmit} display="flex" gap={2} flexWrap="wrap">
+      <TextField label="Quelle" value={source} onChange={(e) => setSource(e.target.value)} fullWidth />
+      <TextField label="Betrag (€)" type="number" value={amount} onChange={(e) => setAmount(e.target.value)} />
+      <Button type="submit" variant="contained">
+        Hinzufügen
+      </Button>
+      {error && (
+        <Typography color="error" sx={{ mt: 2 }}>
+          {error}
+        </Typography>
+      )}
+    </Box>
+  );
+}

--- a/internal/ui/src/components/IncomeTable.jsx
+++ b/internal/ui/src/components/IncomeTable.jsx
@@ -1,0 +1,39 @@
+import { Table, TableHead, TableBody, TableRow, TableCell, Button } from "@mui/material";
+
+export default function IncomeTable({ incomes, onEdit, onDelete }) {
+  return (
+    <Table>
+      <TableHead>
+        <TableRow>
+          <TableCell>Quelle</TableCell>
+          <TableCell align="right">Betrag (€)</TableCell>
+          <TableCell>Aktionen</TableCell>
+        </TableRow>
+      </TableHead>
+      <TableBody>
+        {incomes.length > 0 ? (
+          incomes.map((i) => (
+            <TableRow key={i.id} hover>
+              <TableCell>{i.source}</TableCell>
+              <TableCell align="right">{i.amount.toFixed(2)}</TableCell>
+              <TableCell>
+                <Button size="small" onClick={() => onEdit(i)}>
+                  Bearbeiten
+                </Button>
+                <Button size="small" color="error" onClick={() => onDelete(i.id)}>
+                  Löschen
+                </Button>
+              </TableCell>
+            </TableRow>
+          ))
+        ) : (
+          <TableRow>
+            <TableCell colSpan={3} align="center">
+              Keine Einnahmen vorhanden
+            </TableCell>
+          </TableRow>
+        )}
+      </TableBody>
+    </Table>
+  );
+}

--- a/internal/ui/src/components/MemberForm.jsx
+++ b/internal/ui/src/components/MemberForm.jsx
@@ -1,0 +1,37 @@
+import { useState } from "react";
+import { Box, TextField, Button, Typography } from "@mui/material";
+
+export default function MemberForm({ onSubmit }) {
+  const [name, setName] = useState("");
+  const [email, setEmail] = useState("");
+  const [date, setDate] = useState("");
+  const [error, setError] = useState("");
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    if (!name || !email || !date) {
+      setError("Alle Felder erforderlich");
+      return;
+    }
+    await onSubmit(name, email, date, setError);
+    setName("");
+    setEmail("");
+    setDate("");
+  };
+
+  return (
+    <Box component="form" onSubmit={handleSubmit} display="flex" gap={2} flexWrap="wrap">
+      <TextField label="Name" value={name} onChange={(e) => setName(e.target.value)} />
+      <TextField label="Email" value={email} onChange={(e) => setEmail(e.target.value)} />
+      <TextField label="Beitrittsdatum" type="date" InputLabelProps={{ shrink: true }} value={date} onChange={(e) => setDate(e.target.value)} />
+      <Button type="submit" variant="contained">
+        Hinzufügen
+      </Button>
+      {error && (
+        <Typography color="error" sx={{ mt: 2 }}>
+          {error}
+        </Typography>
+      )}
+    </Box>
+  );
+}

--- a/internal/ui/src/components/MemberPanel.jsx
+++ b/internal/ui/src/components/MemberPanel.jsx
@@ -1,0 +1,42 @@
+import { useState, useEffect } from "react";
+import { Paper, Typography } from "@mui/material";
+import MemberForm from "./MemberForm";
+import MemberTable from "./MemberTable";
+import { AddMember, ListMembers } from "../wailsjs/go/service/DataService";
+
+export default function MemberPanel() {
+  const [members, setMembers] = useState([]);
+
+  const fetchMembers = async () => {
+    const list = await ListMembers();
+    setMembers(list || []);
+  };
+
+  useEffect(() => {
+    fetchMembers();
+  }, []);
+
+  const submit = async (name, email, date, setError) => {
+    try {
+      await AddMember(name, email, date);
+      setError("");
+      fetchMembers();
+    } catch (err) {
+      setError(err.message || "Fehler beim Hinzufügen");
+    }
+  };
+
+  return (
+    <>
+      <Paper sx={{ p: 3, mb: 4 }}>
+        <Typography variant="h6" component="h2" gutterBottom>
+          Neues Mitglied
+        </Typography>
+        <MemberForm onSubmit={submit} />
+      </Paper>
+      <Paper>
+        <MemberTable members={members} />
+      </Paper>
+    </>
+  );
+}

--- a/internal/ui/src/components/MemberTable.jsx
+++ b/internal/ui/src/components/MemberTable.jsx
@@ -1,0 +1,24 @@
+import { Table, TableHead, TableRow, TableCell, TableBody } from "@mui/material";
+
+export default function MemberTable({ members }) {
+  return (
+    <Table size="small">
+      <TableHead>
+        <TableRow>
+          <TableCell>Name</TableCell>
+          <TableCell>Email</TableCell>
+          <TableCell>Beitritt</TableCell>
+        </TableRow>
+      </TableHead>
+      <TableBody>
+        {members.map((m) => (
+          <TableRow key={m.id}>
+            <TableCell>{m.name}</TableCell>
+            <TableCell>{m.email}</TableCell>
+            <TableCell>{m.join_date || m.joinDate}</TableCell>
+          </TableRow>
+        ))}
+      </TableBody>
+    </Table>
+  );
+}

--- a/internal/ui/src/components/TaxPanel.jsx
+++ b/internal/ui/src/components/TaxPanel.jsx
@@ -1,0 +1,39 @@
+import { useState } from "react";
+import { Box, Button, Typography } from "@mui/material";
+import { CalculateProjectTaxes } from "../wailsjs/go/service/DataService";
+
+export default function TaxPanel() {
+  const [taxes, setTaxes] = useState(null);
+  const [error, setError] = useState("");
+
+  const handleCalculate = async () => {
+    try {
+      const result = await CalculateProjectTaxes(1);
+      setTaxes(result);
+      setError("");
+    } catch (err) {
+      setError(err.message || "Fehler bei Berechnung");
+    }
+  };
+
+  return (
+    <Box>
+      <Button variant="contained" color="secondary" onClick={handleCalculate}>
+        Steuern berechnen
+      </Button>
+      {taxes && (
+        <Box sx={{ mt: 2 }}>
+          <Typography>Einnahmen: {taxes.revenue.toFixed(2)} €</Typography>
+          <Typography>Ausgaben: {taxes.expenses.toFixed(2)} €</Typography>
+          <Typography>Steuerpflichtiges Einkommen: {taxes.taxableIncome.toFixed(2)} €</Typography>
+          <Typography>Gesamtsteuer: {taxes.totalTax.toFixed(2)} €</Typography>
+        </Box>
+      )}
+      {error && (
+        <Typography color="error" sx={{ mt: 2 }}>
+          {error}
+        </Typography>
+      )}
+    </Box>
+  );
+}

--- a/internal/ui/src/wailsjs/go/pdf/Generator.js
+++ b/internal/ui/src/wailsjs/go/pdf/Generator.js
@@ -25,3 +25,7 @@ export function GenerateAnlageSport(projectID) {
 export function GenerateAllForms(projectID) {
   return window.go.pdf.Generator.GenerateAllForms(projectID);
 }
+
+export function GenerateFormsArchive(projectID) {
+  return window.go.pdf.Generator.GenerateFormsArchive(projectID);
+}

--- a/internal/ui/src/wailsjs/go/service/DataService.js
+++ b/internal/ui/src/wailsjs/go/service/DataService.js
@@ -37,3 +37,11 @@ export function ListIncomes(arg1) {
 export function CalculateProjectTaxes(arg1) {
   return window.go.service.DataService.CalculateProjectTaxes(arg1);
 }
+
+export function AddMember(arg1, arg2, arg3) {
+  return window.go.service.DataService.AddMember(arg1, arg2, arg3);
+}
+
+export function ListMembers() {
+  return window.go.service.DataService.ListMembers();
+}

--- a/scripts/package.sh
+++ b/scripts/package.sh
@@ -12,7 +12,7 @@ OUTPUT_DIR="$ROOT_DIR/build/bin/$VERSION"
 rm -rf "$OUTPUT_DIR"
 mkdir -p "$OUTPUT_DIR"
 
-PLATFORMS=("darwin/universal" "windows/amd64")
+PLATFORMS=("darwin/universal" "windows/amd64" "linux/amd64" "linux/arm64")
 
 for PLATFORM in "${PLATFORMS[@]}"; do
     echo "==> Building for $PLATFORM"
@@ -21,6 +21,7 @@ for PLATFORM in "${PLATFORMS[@]}"; do
     case "$PLATFORM" in
         darwin/*)  TARGET="macos";;
         windows/*) TARGET="windows";;
+        linux/*)   TARGET="linux";;
         *)         TARGET="$PLATFORM";;
     esac
 


### PR DESCRIPTION
## Summary
- support `-loglevel` flag to adjust verbosity
- archive all generated forms into a ZIP
- add React components for member management
- provide ZIP generation button in the forms panel
- expose member functions in wails bindings and update tests

## Testing
- `go test ./cmd/... ./internal/... ./internal/pdf/...`
- `npm ci --prefix internal/ui`
- `npm test --prefix internal/ui`


------
https://chatgpt.com/codex/tasks/task_e_6866fdea7d408333a431011b00b5d326