### PR TITLE
Add member index and test

### DIFF
--- a/internal/data/store.go
+++ b/internal/data/store.go
@@ -60,6 +60,9 @@ func (s *Store) init() error {
 			return err
 		}
 	}
+	if _, err := s.DB.Exec(`CREATE INDEX IF NOT EXISTS idx_members_name ON members(name);`); err != nil {
+		return err
+	}
 	return nil
 }
 

--- a/internal/data/store_test.go
+++ b/internal/data/store_test.go
@@ -196,3 +196,25 @@ func TestStore_MemberIndexExists(t *testing.T) {
 		t.Fatalf("members name index not created")
 	}
 }
+
+func TestMemberQueryByName(t *testing.T) {
+	s, err := NewStore(":memory:")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer s.Close()
+
+	m := &Member{Name: "Bob", Email: "bob@example.com", JoinDate: "2024-01-03"}
+	if err := s.CreateMember(m); err != nil {
+		t.Fatal(err)
+	}
+
+	row := s.DB.QueryRow(`SELECT id, name, email, join_date FROM members WHERE name=?`, m.Name)
+	var got Member
+	if err := row.Scan(&got.ID, &got.Name, &got.Email, &got.JoinDate); err != nil {
+		t.Fatal(err)
+	}
+	if got.ID != m.ID || got.Email != m.Email {
+		t.Fatalf("queried member mismatch: %+v vs %+v", got, m)
+	}
+}


### PR DESCRIPTION
## Summary
- ensure members table has index on name during init
- test querying members by name with the new index

## Testing
- `go test ./internal/...`


------
https://chatgpt.com/codex/tasks/task_e_68678525f2c48333a17b2e097eb87cc5