### PR TITLE
Add amount validation helper

### DIFF
--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -12,6 +12,13 @@ import (
 
 var ErrInvalidAmount = errors.New("amount must be positive")
 
+func validateAmount(amount float64) error {
+	if amount <= 0 {
+		return fmt.Errorf("invalid amount: %w", ErrInvalidAmount)
+	}
+	return nil
+}
+
 // DataService provides application methods used by the UI.
 type DataService struct {
 	store  *data.Store
@@ -72,8 +79,8 @@ func (ds *DataService) ListIncomes(projectID int64) ([]data.Income, error) {
 
 // AddIncome adds a new income to the given project.
 func (ds *DataService) AddIncome(projectID int64, source string, amount float64) (*data.Income, error) {
-	if amount <= 0 {
-		return nil, fmt.Errorf("invalid amount: %w", ErrInvalidAmount)
+	if err := validateAmount(amount); err != nil {
+		return nil, err
 	}
 	i := &data.Income{ProjectID: projectID, Source: source, Amount: amount}
 	if err := ds.store.CreateIncome(i); err != nil {
@@ -85,8 +92,8 @@ func (ds *DataService) AddIncome(projectID int64, source string, amount float64)
 
 // UpdateIncome updates an existing income entry.
 func (ds *DataService) UpdateIncome(id int64, projectID int64, source string, amount float64) error {
-	if amount <= 0 {
-		return fmt.Errorf("invalid amount: %w", ErrInvalidAmount)
+	if err := validateAmount(amount); err != nil {
+		return err
 	}
 	i := &data.Income{ID: id, ProjectID: projectID, Source: source, Amount: amount}
 	if err := ds.store.UpdateIncome(i); err != nil {
@@ -107,8 +114,8 @@ func (ds *DataService) DeleteIncome(id int64) error {
 
 // AddExpense adds a new expense to the given project.
 func (ds *DataService) AddExpense(projectID int64, category string, amount float64) (*data.Expense, error) {
-	if amount <= 0 {
-		return nil, fmt.Errorf("invalid amount: %w", ErrInvalidAmount)
+	if err := validateAmount(amount); err != nil {
+		return nil, err
 	}
 	e := &data.Expense{ProjectID: projectID, Category: category, Amount: amount}
 	if err := ds.store.CreateExpense(e); err != nil {
@@ -120,8 +127,8 @@ func (ds *DataService) AddExpense(projectID int64, category string, amount float
 
 // UpdateExpense updates an existing expense entry.
 func (ds *DataService) UpdateExpense(id int64, projectID int64, category string, amount float64) error {
-	if amount <= 0 {
-		return fmt.Errorf("invalid amount: %w", ErrInvalidAmount)
+	if err := validateAmount(amount); err != nil {
+		return err
 	}
 	e := &data.Expense{ID: id, ProjectID: projectID, Category: category, Amount: amount}
 	if err := ds.store.UpdateExpense(e); err != nil {

--- a/internal/service/service_test.go
+++ b/internal/service/service_test.go
@@ -247,3 +247,13 @@ func TestDataService_InvalidAmounts(t *testing.T) {
 		t.Fatalf("expected invalid amount error, got %v", err)
 	}
 }
+
+func TestValidateAmount(t *testing.T) {
+	if err := validateAmount(10); err != nil {
+		t.Fatalf("expected nil error, got %v", err)
+	}
+	err := validateAmount(0)
+	if err == nil || !errors.Is(err, ErrInvalidAmount) {
+		t.Fatalf("expected invalid amount error, got %v", err)
+	}
+}


### PR DESCRIPTION
## Summary
- validate income/expense amounts using a helper
- cover the helper in tests

## Testing
- `go work sync`
- `go test ./cmd/... ./internal/... ./internal/pdf/...`


------
https://chatgpt.com/codex/tasks/task_e_68678521077c8333aefb9f310ee45232