### PR TITLE
Fix duplicate index creation

### DIFF
--- a/internal/data/store.go
+++ b/internal/data/store.go
@@ -64,9 +64,6 @@ func (s *Store) init() error {
 			return err
 		}
 	}
-	if _, err := s.DB.Exec(`CREATE INDEX IF NOT EXISTS idx_members_name ON members(name);`); err != nil {
-		return err
-	}
 	return nil
 }
 


### PR DESCRIPTION
## Summary
- remove duplicate index creation in internal/data/store.go
- keep schema slice responsible for creating member name index

## Testing
- `go test ./internal/...` *(fails: go commands can't finish downloading modules)*

------
https://chatgpt.com/codex/tasks/task_e_6867a674f3f88333bbc04009e14ea066