### PR TITLE
Refactor main to reuse store

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -48,15 +48,10 @@ func main() {
 		fmt.Println("Error:", err)
 		return
 	}
-	defer store.Close()
 
 	logger, logCloser := service.NewLogger(cfg.LogFile, cfg.LogLevel)
 	generator := pdf.NewGenerator(cfg.PDFDir, store)
-	datasvc, err := service.NewDataService(cfg.DBPath, logger, logCloser)
-	if err != nil {
-		fmt.Println("Error:", err)
-		return
-	}
+	datasvc := service.NewDataServiceFromStore(store, logger, logCloser)
 	defer datasvc.Close()
 
 	err = wails.Run(&options.App{


### PR DESCRIPTION
## Summary
- open database once in main
- reuse that store for the PDF generator and data service
- remove redundant `store.Close()` call

## Testing
- `go test ./cmd/... ./internal/... ./internal/pdf/...`

------
https://chatgpt.com/codex/tasks/task_e_6867c32a27888333a4a1e7287975c07a