### PR TITLE
Implement user authentication with login dialog

### DIFF
--- a/internal/data/models.go
+++ b/internal/data/models.go
@@ -29,3 +29,10 @@ type Member struct {
 	Email    string `db:"email"`
 	JoinDate string `db:"join_date"`
 }
+
+// User represents an application user.
+type User struct {
+	ID           int64  `db:"id"`
+	Username     string `db:"username"`
+	PasswordHash string `db:"password_hash"`
+}

--- a/internal/data/store_test.go
+++ b/internal/data/store_test.go
@@ -231,3 +231,25 @@ func TestMemberQueryByName(t *testing.T) {
 		t.Fatalf("queried member mismatch: %+v vs %+v", got, m)
 	}
 }
+
+func TestStore_UserCRUD(t *testing.T) {
+	s, err := NewStore(":memory:")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer s.Close()
+
+	ctx := context.Background()
+
+	u := &User{Username: "alice", PasswordHash: "hash"}
+	if err := s.CreateUser(ctx, u); err != nil {
+		t.Fatal(err)
+	}
+	got, err := s.GetUserByUsername(ctx, "alice")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.ID != u.ID || got.PasswordHash != u.PasswordHash {
+		t.Fatalf("expected %+v got %+v", u, got)
+	}
+}

--- a/internal/ui/src/App.jsx
+++ b/internal/ui/src/App.jsx
@@ -2,6 +2,7 @@ import { useState, useEffect } from "react";
 import { ThemeProvider, createTheme } from "@mui/material/styles";
 import { CssBaseline, Container, FormControlLabel, Switch, AppBar, Toolbar, Typography, Tabs, Tab, Paper } from "@mui/material";
 import { ListExpenses, ListIncomes, AddIncome, UpdateIncome, DeleteIncome, AddExpense, UpdateExpense, DeleteExpense } from "./wailsjs/go/service/DataService";
+import LoginDialog from "./components/LoginDialog";
 import ProjectPanel from "./components/ProjectPanel";
 import IncomeForm from "./components/IncomeForm";
 import IncomeTable from "./components/IncomeTable";
@@ -16,6 +17,7 @@ export default function App() {
   const [editIncome, setEditIncome] = useState(null);
   const [editExpense, setEditExpense] = useState(null);
   const [darkMode, setDarkMode] = useState(false);
+  const [loggedIn, setLoggedIn] = useState(false);
   const [tab, setTab] = useState(1);
   const [projectId, setProjectId] = useState(1);
 
@@ -37,9 +39,10 @@ export default function App() {
   };
 
   useEffect(() => {
+    if (!loggedIn) return;
     fetchExpenses();
     fetchIncomes();
-  }, [projectId]);
+  }, [projectId, loggedIn]);
 
   const submitIncome = async (source, amount, setError) => {
     try {
@@ -74,24 +77,27 @@ export default function App() {
   return (
     <ThemeProvider theme={theme}>
       <CssBaseline />
-      <AppBar position="static" color="primary">
-        <Toolbar>
-          <Typography variant="h6" sx={{ flexGrow: 1 }}>
-            Baristeuer
-          </Typography>
-          <FormControlLabel
-            control={<Switch checked={darkMode} onChange={() => setDarkMode(!darkMode)} color="default" />}
-            label={darkMode ? "Dunkel" : "Hell"}
-          />
-        </Toolbar>
-        <Tabs value={tab} onChange={(_, v) => setTab(v)} textColor="inherit" indicatorColor="secondary" centered>
-          <Tab label="Projekte" />
-          <Tab label="Einnahmen" />
-          <Tab label="Ausgaben" />
-          <Tab label="Formulare" />
-          <Tab label="Steuern" />
-        </Tabs>
-      </AppBar>
+      <LoginDialog open={!loggedIn} onSuccess={() => setLoggedIn(true)} />
+      {loggedIn && (
+        <>
+          <AppBar position="static" color="primary">
+            <Toolbar>
+              <Typography variant="h6" sx={{ flexGrow: 1 }}>
+                Baristeuer
+              </Typography>
+              <FormControlLabel
+                control={<Switch checked={darkMode} onChange={() => setDarkMode(!darkMode)} color="default" />}
+                label={darkMode ? "Dunkel" : "Hell"}
+              />
+            </Toolbar>
+            <Tabs value={tab} onChange={(_, v) => setTab(v)} textColor="inherit" indicatorColor="secondary" centered>
+              <Tab label="Projekte" />
+              <Tab label="Einnahmen" />
+              <Tab label="Ausgaben" />
+              <Tab label="Formulare" />
+              <Tab label="Steuern" />
+            </Tabs>
+          </AppBar>
       <Container maxWidth="md" sx={{ py: 4 }}>
         {tab === 0 && (
           <ProjectPanel activeId={projectId} onSelect={(id) => setProjectId(id)} />
@@ -143,6 +149,8 @@ export default function App() {
           </Paper>
         )}
       </Container>
+        </>
+      )}
     </ThemeProvider>
   );
 }

--- a/internal/ui/src/LoginDialog.test.jsx
+++ b/internal/ui/src/LoginDialog.test.jsx
@@ -1,0 +1,37 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { vi, beforeEach } from 'vitest';
+import LoginDialog from './components/LoginDialog';
+
+vi.mock('./wailsjs/go/service/DataService', () => ({
+  AuthenticateUser: vi.fn(),
+  CreateUser: vi.fn(),
+}), { virtual: true });
+
+import { AuthenticateUser, CreateUser } from './wailsjs/go/service/DataService';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+test('logs in successfully', async () => {
+  AuthenticateUser.mockResolvedValueOnce('tok');
+  render(<LoginDialog open={true} onSuccess={vi.fn()} />);
+  fireEvent.change(screen.getByLabelText(/Benutzername/i), { target: { value: 'a' } });
+  fireEvent.change(screen.getByLabelText(/Passwort/i), { target: { value: 'b' } });
+  fireEvent.click(screen.getByRole('button', { name: 'OK' }));
+  await waitFor(() => expect(AuthenticateUser).toHaveBeenCalledWith('a', 'b'));
+});
+
+test('registers new user', async () => {
+  CreateUser.mockResolvedValueOnce();
+  AuthenticateUser.mockResolvedValueOnce('tok');
+  const onSuccess = vi.fn();
+  render(<LoginDialog open={true} onSuccess={onSuccess} />);
+  fireEvent.click(screen.getByRole('button', { name: /Registrieren/i }));
+  fireEvent.change(screen.getByLabelText(/Benutzername/i), { target: { value: 'x' } });
+  fireEvent.change(screen.getByLabelText(/Passwort/i), { target: { value: 'y' } });
+  fireEvent.click(screen.getByRole('button', { name: 'OK' }));
+  await waitFor(() => expect(CreateUser).toHaveBeenCalledWith('x', 'y'));
+  await waitFor(() => expect(onSuccess).toHaveBeenCalled());
+});

--- a/internal/ui/src/components/LoginDialog.jsx
+++ b/internal/ui/src/components/LoginDialog.jsx
@@ -1,0 +1,57 @@
+import { useState } from "react";
+import {
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  TextField,
+  Button,
+  Typography,
+} from "@mui/material";
+import { AuthenticateUser, CreateUser } from "../wailsjs/go/service/DataService";
+
+export default function LoginDialog({ open, onSuccess }) {
+  const [username, setUsername] = useState("");
+  const [password, setPassword] = useState("");
+  const [register, setRegister] = useState(false);
+  const [error, setError] = useState("");
+
+  const handleSubmit = async () => {
+    try {
+      if (register) {
+        await CreateUser(username, password);
+      }
+      await AuthenticateUser(username, password);
+      setError("");
+      onSuccess && onSuccess();
+    } catch (err) {
+      setError(err.message || "Fehler");
+    }
+  };
+
+  return (
+    <Dialog open={open}>
+      <DialogTitle>{register ? "Registrieren" : "Anmelden"}</DialogTitle>
+      <DialogContent sx={{ display: "flex", flexDirection: "column", gap: 2 }}>
+        <TextField
+          label="Benutzername"
+          value={username}
+          onChange={(e) => setUsername(e.target.value)}
+        />
+        <TextField
+          label="Passwort"
+          type="password"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+        />
+        {error && <Typography color="error">{error}</Typography>}
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={() => setRegister(!register)}>
+          {register ? "Login" : "Registrieren"}
+        </Button>
+        <Button onClick={handleSubmit}>OK</Button>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/internal/ui/src/wailsjs/go/service/DataService.js
+++ b/internal/ui/src/wailsjs/go/service/DataService.js
@@ -50,6 +50,14 @@ export function DeleteIncome(arg1) {
   return window.go.service.DataService.DeleteIncome(arg1);
 }
 
+export function CreateUser(arg1, arg2) {
+  return window.go.service.DataService.CreateUser(arg1, arg2);
+}
+
+export function AuthenticateUser(arg1, arg2) {
+  return window.go.service.DataService.AuthenticateUser(arg1, arg2);
+}
+
 export function ListIncomes(arg1) {
   return window.go.service.DataService.ListIncomes(arg1);
 }


### PR DESCRIPTION
## Summary
- add `users` table model and schema
- implement CRUD functions for users in data store
- add user auth methods to service layer
- integrate login dialog in React frontend
- provide vitest coverage for login flow and adapt existing tests

## Testing
- `npm test --prefix internal/ui`
- `go test ./...` in `internal`

------
https://chatgpt.com/codex/tasks/task_e_68681a3f879083338a37c7020f1ff75d