### PR TITLE
Add i18n support

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Bari$teuer is a software tool designed to assist German non-profit organizations
 - **Member Management:** Track club members with join date and contact details.
 - **Tax Overview:** Calculates taxes for a project and displays the results in the UI.
 - **Reporting:** Generates tax reports for submission.
-- **User Interface:** German-language interface styled with Material UI themes.
+- **User Interface:** Interface available in German and English with a language selector, styled with Material UI themes.
 - **Cross-Platform:** Operates on both macOS and Windows.
 - **PDF Export:** Exports financial reports and a set of Vereinssteuerformulare (KSt 1, Anlagen Gem/GK usw.) to PDF format.
 
@@ -57,6 +57,8 @@ A minimal `config.json` might look like:
 ```
 
 Run `./baristeuer -config config.json` to load these settings.
+
+The UI language can be switched between German and English using the dropdown in the top toolbar.
 
 Follow the official documentation for platform specific details.
 

--- a/docs/DOCUMENTATION.md
+++ b/docs/DOCUMENTATION.md
@@ -78,9 +78,13 @@ application looks for `config.json` in the working directory. Example:
 
 Command line flags override values from the file.
 
+### Language Selection
+The application starts in German. Use the dropdown in the top toolbar to switch between German and English at any time.
+
 ## Key Features
 
 - **React + Material UI Interface**: UI built with React components styled using Material UI.
+- **Multi-language Support**: Interface available in German and English. Change the language via the toolbar dropdown.
 - **PDF Generation**: Creates detailed tax reports in PDF format for submission to the German tax office.
 - **SQLite Storage**: Simple persistence layer to store project data.
 - **Member Tracking**: Manage club members with names, emails and join dates.

--- a/internal/ui/package-lock.json
+++ b/internal/ui/package-lock.json
@@ -11,8 +11,10 @@
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.14.1",
         "@mui/material": "^5.15.8",
+        "i18next": "^23.10.0",
         "react": "^19.1.0",
-        "react-dom": "^19.1.0"
+        "react-dom": "^19.1.0",
+        "react-i18next": "^13.2.1"
       },
       "devDependencies": {
         "@eslint/js": "^9.30.1",
@@ -3130,6 +3132,15 @@
         "node": ">=18"
       }
     },
+    "node_modules/html-parse-stringify": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/html-parse-stringify/-/html-parse-stringify-3.0.1.tgz",
+      "integrity": "sha512-KknJ50kTInJ7qIScF3jeaFRpMpE8/lfiTdzf/twXyPBLAGrLRTmkz3AdTnKeh40X8k9L2fdYwEp/42WGXIRGcg==",
+      "license": "MIT",
+      "dependencies": {
+        "void-elements": "3.1.0"
+      }
+    },
     "node_modules/http-proxy-agent": {
       "version": "7.0.2",
       "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
@@ -3156,6 +3167,29 @@
       },
       "engines": {
         "node": ">= 14"
+      }
+    },
+    "node_modules/i18next": {
+      "version": "23.16.8",
+      "resolved": "https://registry.npmjs.org/i18next/-/i18next-23.16.8.tgz",
+      "integrity": "sha512-06r/TitrM88Mg5FdUXAKL96dJMzgqLE5dv3ryBAra4KCwD9mJ4ndOTS95ZuymIGoE+2hzfdaMak2X11/es7ZWg==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://locize.com"
+        },
+        {
+          "type": "individual",
+          "url": "https://locize.com/i18next.html"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.i18next.com/how-to/faq#i18next-is-awesome.-how-can-i-support-the-project"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.23.2"
       }
     },
     "node_modules/iconv-lite": {
@@ -4118,6 +4152,28 @@
         "react": "^19.1.0"
       }
     },
+    "node_modules/react-i18next": {
+      "version": "13.5.0",
+      "resolved": "https://registry.npmjs.org/react-i18next/-/react-i18next-13.5.0.tgz",
+      "integrity": "sha512-CFJ5NDGJ2MUyBohEHxljOq/39NQ972rh1ajnadG9BjTk+UXbHLq4z5DKEbEQBDoIhUmmbuS/fIMJKo6VOax1HA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.22.5",
+        "html-parse-stringify": "^3.0.1"
+      },
+      "peerDependencies": {
+        "i18next": ">= 23.2.3",
+        "react": ">= 16.8.0"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        },
+        "react-native": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/react-is": {
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
@@ -4755,6 +4811,15 @@
         "jsdom": {
           "optional": true
         }
+      }
+    },
+    "node_modules/void-elements": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/void-elements/-/void-elements-3.1.0.tgz",
+      "integrity": "sha512-Dhxzh5HZuiHQhbvTW9AMetFfBHDMYpo23Uo9btPXgdYP+3T5S+p+jgNy7spra+veYhBP2dCSgxR/i2Y02h5/6w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/w3c-xmlserializer": {

--- a/internal/ui/package.json
+++ b/internal/ui/package.json
@@ -16,7 +16,9 @@
     "@emotion/styled": "^11.14.1",
     "@mui/material": "^5.15.8",
     "react": "^19.1.0",
-    "react-dom": "^19.1.0"
+    "react-dom": "^19.1.0",
+    "i18next": "^23.10.0",
+    "react-i18next": "^13.2.1"
   },
   "devDependencies": {
     "@eslint/js": "^9.30.1",

--- a/internal/ui/src/App.jsx
+++ b/internal/ui/src/App.jsx
@@ -1,6 +1,8 @@
 import { useState, useEffect } from "react";
 import { ThemeProvider, createTheme } from "@mui/material/styles";
-import { CssBaseline, Container, FormControlLabel, Switch, AppBar, Toolbar, Typography, Tabs, Tab, Paper } from "@mui/material";
+import { CssBaseline, Container, FormControlLabel, Switch, AppBar, Toolbar, Typography, Tabs, Tab, Paper, Select, MenuItem } from "@mui/material";
+import { useTranslation } from "react-i18next";
+import "./i18n";
 import { ListExpenses, ListIncomes, AddIncome, UpdateIncome, DeleteIncome, AddExpense, UpdateExpense, DeleteExpense } from "./wailsjs/go/service/DataService";
 import ProjectPanel from "./components/ProjectPanel";
 import IncomeForm from "./components/IncomeForm";
@@ -18,6 +20,8 @@ export default function App() {
   const [darkMode, setDarkMode] = useState(false);
   const [tab, setTab] = useState(1);
   const [projectId, setProjectId] = useState(1);
+  const { t, i18n } = useTranslation();
+  const [language, setLanguage] = useState(i18n.language);
 
   const theme = createTheme({
     palette: {
@@ -36,6 +40,12 @@ export default function App() {
     setIncomes(list || []);
   };
 
+  const handleLanguageChange = (e) => {
+    const lng = e.target.value;
+    i18n.changeLanguage(lng);
+    setLanguage(lng);
+  };
+
   useEffect(() => {
     fetchExpenses();
     fetchIncomes();
@@ -52,7 +62,7 @@ export default function App() {
       setError("");
       fetchIncomes();
     } catch (err) {
-      setError(err.message || "Fehler beim Hinzufügen");
+      setError(err.message || t('add_error'));
     }
   };
 
@@ -67,7 +77,7 @@ export default function App() {
       setError("");
       fetchExpenses();
     } catch (err) {
-      setError(err.message || "Fehler beim Hinzufügen");
+      setError(err.message || t('add_error'));
     }
   };
 
@@ -79,17 +89,27 @@ export default function App() {
           <Typography variant="h6" sx={{ flexGrow: 1 }}>
             Baristeuer
           </Typography>
+          <Select
+            value={language}
+            onChange={handleLanguageChange}
+            size="small"
+            sx={{ mr: 2, color: 'inherit' }}
+            variant="standard"
+          >
+            <MenuItem value="de">DE</MenuItem>
+            <MenuItem value="en">EN</MenuItem>
+          </Select>
           <FormControlLabel
             control={<Switch checked={darkMode} onChange={() => setDarkMode(!darkMode)} color="default" />}
-            label={darkMode ? "Dunkel" : "Hell"}
+            label={darkMode ? t('theme.dark') : t('theme.light')}
           />
         </Toolbar>
         <Tabs value={tab} onChange={(_, v) => setTab(v)} textColor="inherit" indicatorColor="secondary" centered>
-          <Tab label="Projekte" />
-          <Tab label="Einnahmen" />
-          <Tab label="Ausgaben" />
-          <Tab label="Formulare" />
-          <Tab label="Steuern" />
+          <Tab label={t('tab.projects')} />
+          <Tab label={t('tab.incomes')} />
+          <Tab label={t('tab.expenses')} />
+          <Tab label={t('tab.forms')} />
+          <Tab label={t('tab.taxes')} />
         </Tabs>
       </AppBar>
       <Container maxWidth="md" sx={{ py: 4 }}>
@@ -100,7 +120,7 @@ export default function App() {
           <>
             <Paper sx={{ p: 3, mb: 4 }}>
               <Typography variant="h6" component="h2" gutterBottom>
-                Neue Einnahme
+                {t('income.new')}
               </Typography>
               <IncomeForm onSubmit={submitIncome} editItem={editIncome} />
             </Paper>
@@ -120,7 +140,7 @@ export default function App() {
           <>
             <Paper sx={{ p: 3, mb: 4 }}>
               <Typography variant="h6" component="h2" gutterBottom>
-                Neue Ausgabe
+                {t('expense.new')}
               </Typography>
               <ExpenseForm onSubmit={submitExpense} editItem={editExpense} />
             </Paper>

--- a/internal/ui/src/App.test.jsx
+++ b/internal/ui/src/App.test.jsx
@@ -2,6 +2,7 @@ import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import { vi, beforeEach } from 'vitest';
 import App from './App';
+import './i18n';
 
 // mock the DataService module used by App
 vi.mock('./wailsjs/go/service/DataService', () => ({

--- a/internal/ui/src/components/ExpenseForm.jsx
+++ b/internal/ui/src/components/ExpenseForm.jsx
@@ -1,20 +1,22 @@
 import { useState } from "react";
 import { Box, TextField, Button, Typography } from "@mui/material";
+import { useTranslation } from "react-i18next";
 
 export default function ExpenseForm({ onSubmit, editItem }) {
   const [description, setDescription] = useState(editItem ? editItem.description : "");
   const [amount, setAmount] = useState(editItem ? String(editItem.amount) : "");
   const [error, setError] = useState("");
+  const { t } = useTranslation();
 
   const handleSubmit = async (e) => {
     e.preventDefault();
     const value = parseFloat(amount);
     if (!description || !amount) {
-      setError("Beschreibung und Betrag erforderlich");
+      setError(t('expense.required'));
       return;
     }
     if (Number.isNaN(value) || value <= 0) {
-      setError("Betrag muss eine positive Zahl sein");
+      setError(t('expense.positive'));
       return;
     }
     await onSubmit(description, value, setError);
@@ -26,10 +28,10 @@ export default function ExpenseForm({ onSubmit, editItem }) {
 
   return (
     <Box component="form" onSubmit={handleSubmit} display="flex" gap={2} flexWrap="wrap">
-      <TextField label="Beschreibung" value={description} onChange={(e) => setDescription(e.target.value)} fullWidth />
-      <TextField label="Betrag (€)" type="number" value={amount} onChange={(e) => setAmount(e.target.value)} />
+      <TextField label={t('expense.description')} value={description} onChange={(e) => setDescription(e.target.value)} fullWidth />
+      <TextField label={t('expense.amount')} type="number" value={amount} onChange={(e) => setAmount(e.target.value)} />
       <Button type="submit" variant="contained">
-        Hinzufügen
+        {t('expense.add')}
       </Button>
       {error && (
         <Typography color="error" sx={{ mt: 2 }}>

--- a/internal/ui/src/components/ExpenseTable.jsx
+++ b/internal/ui/src/components/ExpenseTable.jsx
@@ -1,13 +1,15 @@
 import { Table, TableHead, TableBody, TableRow, TableCell, Button } from "@mui/material";
+import { useTranslation } from "react-i18next";
 
 export default function ExpenseTable({ expenses, onEdit, onDelete }) {
+  const { t } = useTranslation();
   return (
     <Table>
       <TableHead>
         <TableRow>
-          <TableCell>Beschreibung</TableCell>
-          <TableCell align="right">Betrag (€)</TableCell>
-          <TableCell>Aktionen</TableCell>
+          <TableCell>{t('expense.table.description')}</TableCell>
+          <TableCell align="right">{t('expense.table.amount')}</TableCell>
+          <TableCell>{t('expense.table.actions')}</TableCell>
         </TableRow>
       </TableHead>
       <TableBody>
@@ -18,10 +20,10 @@ export default function ExpenseTable({ expenses, onEdit, onDelete }) {
               <TableCell align="right">{e.amount.toFixed(2)}</TableCell>
               <TableCell>
                 <Button size="small" onClick={() => onEdit(e)}>
-                  Bearbeiten
+                  {t('edit')}
                 </Button>
                 <Button size="small" color="error" onClick={() => onDelete(e.id)}>
-                  Löschen
+                  {t('delete')}
                 </Button>
               </TableCell>
             </TableRow>
@@ -29,7 +31,7 @@ export default function ExpenseTable({ expenses, onEdit, onDelete }) {
         ) : (
           <TableRow>
             <TableCell colSpan={3} align="center">
-              Keine Ausgaben vorhanden
+              {t('expense.table.empty')}
             </TableCell>
           </TableRow>
         )}

--- a/internal/ui/src/components/FormsPanel.jsx
+++ b/internal/ui/src/components/FormsPanel.jsx
@@ -8,6 +8,7 @@ import {
   Alert,
 } from "@mui/material";
 import { useState } from "react";
+import { useTranslation } from "react-i18next";
 import {
   GenerateAllForms,
   GenerateAnlageGem,
@@ -19,12 +20,13 @@ import {
 
 export default function FormsPanel({ projectId }) {
   const [error, setError] = useState("");
+  const { t } = useTranslation();
 
   const handleGenerate = async (fn) => {
     try {
       await fn(projectId);
     } catch (err) {
-      setError(err.message || "Fehler beim Erstellen");
+      setError(err.message || t('forms.error'));
     }
   };
 
@@ -38,18 +40,18 @@ export default function FormsPanel({ projectId }) {
             color="secondary"
             onClick={() => handleGenerate(GenerateAllForms)}
           >
-            Alle Formulare erstellen
+            {t('forms.generate_all')}
           </Button>
         </Grid>
         <Grid item xs={12} sm={6}>
           <Card>
             <CardContent>
-              <Typography gutterBottom>KSt 1</Typography>
+              <Typography gutterBottom>{t('form.kst1')}</Typography>
               <Button
                 variant="outlined"
                 onClick={() => handleGenerate(GenerateKSt1)}
               >
-                Erstellen
+                {t('form.generate')}
               </Button>
             </CardContent>
           </Card>
@@ -57,12 +59,12 @@ export default function FormsPanel({ projectId }) {
         <Grid item xs={12} sm={6}>
           <Card>
             <CardContent>
-              <Typography gutterBottom>Anlage Gem</Typography>
+              <Typography gutterBottom>{t('form.anlageGem')}</Typography>
               <Button
                 variant="outlined"
                 onClick={() => handleGenerate(GenerateAnlageGem)}
               >
-                Erstellen
+                {t('form.generate')}
               </Button>
             </CardContent>
           </Card>
@@ -70,12 +72,12 @@ export default function FormsPanel({ projectId }) {
         <Grid item xs={12} sm={6}>
           <Card>
             <CardContent>
-              <Typography gutterBottom>Anlage GK</Typography>
+              <Typography gutterBottom>{t('form.anlageGK')}</Typography>
               <Button
                 variant="outlined"
                 onClick={() => handleGenerate(GenerateAnlageGK)}
               >
-                Erstellen
+                {t('form.generate')}
               </Button>
             </CardContent>
           </Card>
@@ -83,12 +85,12 @@ export default function FormsPanel({ projectId }) {
         <Grid item xs={12} sm={6}>
           <Card>
             <CardContent>
-              <Typography gutterBottom>KSt 1F</Typography>
+              <Typography gutterBottom>{t('form.kst1f')}</Typography>
               <Button
                 variant="outlined"
                 onClick={() => handleGenerate(GenerateKSt1F)}
               >
-                Erstellen
+                {t('form.generate')}
               </Button>
             </CardContent>
           </Card>
@@ -96,12 +98,12 @@ export default function FormsPanel({ projectId }) {
         <Grid item xs={12} sm={6}>
           <Card>
             <CardContent>
-              <Typography gutterBottom>Anlage Sport</Typography>
+              <Typography gutterBottom>{t('form.anlageSport')}</Typography>
               <Button
                 variant="outlined"
                 onClick={() => handleGenerate(GenerateAnlageSport)}
               >
-                Erstellen
+                {t('form.generate')}
               </Button>
             </CardContent>
           </Card>

--- a/internal/ui/src/components/IncomeForm.jsx
+++ b/internal/ui/src/components/IncomeForm.jsx
@@ -1,20 +1,22 @@
 import { useState } from "react";
 import { Box, TextField, Button, Typography } from "@mui/material";
+import { useTranslation } from "react-i18next";
 
 export default function IncomeForm({ onSubmit, editItem }) {
   const [source, setSource] = useState(editItem ? editItem.source : "");
   const [amount, setAmount] = useState(editItem ? String(editItem.amount) : "");
   const [error, setError] = useState("");
+  const { t } = useTranslation();
 
   const handleSubmit = async (e) => {
     e.preventDefault();
     const value = parseFloat(amount);
     if (!source || !amount) {
-      setError("Quelle und Betrag erforderlich");
+      setError(t('income.required'));
       return;
     }
     if (Number.isNaN(value) || value <= 0) {
-      setError("Betrag muss eine positive Zahl sein");
+      setError(t('income.positive'));
       return;
     }
     await onSubmit(source, value, setError);
@@ -26,10 +28,10 @@ export default function IncomeForm({ onSubmit, editItem }) {
 
   return (
     <Box component="form" onSubmit={handleSubmit} display="flex" gap={2} flexWrap="wrap">
-      <TextField label="Quelle" value={source} onChange={(e) => setSource(e.target.value)} fullWidth />
-      <TextField label="Betrag (€)" type="number" value={amount} onChange={(e) => setAmount(e.target.value)} />
+      <TextField label={t('income.source')} value={source} onChange={(e) => setSource(e.target.value)} fullWidth />
+      <TextField label={t('income.amount')} type="number" value={amount} onChange={(e) => setAmount(e.target.value)} />
       <Button type="submit" variant="contained">
-        Hinzufügen
+        {t('income.add')}
       </Button>
       {error && (
         <Typography color="error" sx={{ mt: 2 }}>

--- a/internal/ui/src/components/IncomeTable.jsx
+++ b/internal/ui/src/components/IncomeTable.jsx
@@ -1,13 +1,15 @@
 import { Table, TableHead, TableBody, TableRow, TableCell, Button } from "@mui/material";
+import { useTranslation } from "react-i18next";
 
 export default function IncomeTable({ incomes, onEdit, onDelete }) {
+  const { t } = useTranslation();
   return (
     <Table>
       <TableHead>
         <TableRow>
-          <TableCell>Quelle</TableCell>
-          <TableCell align="right">Betrag (€)</TableCell>
-          <TableCell>Aktionen</TableCell>
+          <TableCell>{t('income.table.source')}</TableCell>
+          <TableCell align="right">{t('income.table.amount')}</TableCell>
+          <TableCell>{t('income.table.actions')}</TableCell>
         </TableRow>
       </TableHead>
       <TableBody>
@@ -18,10 +20,10 @@ export default function IncomeTable({ incomes, onEdit, onDelete }) {
               <TableCell align="right">{i.amount.toFixed(2)}</TableCell>
               <TableCell>
                 <Button size="small" onClick={() => onEdit(i)}>
-                  Bearbeiten
+                  {t('edit')}
                 </Button>
                 <Button size="small" color="error" onClick={() => onDelete(i.id)}>
-                  Löschen
+                  {t('delete')}
                 </Button>
               </TableCell>
             </TableRow>
@@ -29,7 +31,7 @@ export default function IncomeTable({ incomes, onEdit, onDelete }) {
         ) : (
           <TableRow>
             <TableCell colSpan={3} align="center">
-              Keine Einnahmen vorhanden
+              {t('income.table.empty')}
             </TableCell>
           </TableRow>
         )}

--- a/internal/ui/src/components/ProjectPanel.jsx
+++ b/internal/ui/src/components/ProjectPanel.jsx
@@ -8,6 +8,7 @@ import {
   ListItem,
   ListItemText,
 } from "@mui/material";
+import { useTranslation } from "react-i18next";
 import {
   ListProjects,
   CreateProject,
@@ -18,6 +19,7 @@ export default function ProjectPanel({ activeId, onSelect }) {
   const [projects, setProjects] = useState([]);
   const [name, setName] = useState("");
   const [error, setError] = useState("");
+  const { t } = useTranslation();
 
   const fetchProjects = async () => {
     const list = await ListProjects();
@@ -38,7 +40,7 @@ export default function ProjectPanel({ activeId, onSelect }) {
       fetchProjects();
       onSelect && onSelect(p.id);
     } catch (err) {
-      setError(err.message || "Fehler beim Erstellen");
+      setError(err.message || t('project.error'));
     }
   };
 
@@ -51,12 +53,12 @@ export default function ProjectPanel({ activeId, onSelect }) {
     <Box>
       <Box component="form" onSubmit={handleCreate} display="flex" gap={2} mb={2}>
         <TextField
-          label="Neues Projekt"
+          label={t('project.new')}
           value={name}
           onChange={(e) => setName(e.target.value)}
         />
         <Button type="submit" variant="contained">
-          Erstellen
+          {t('project.create')}
         </Button>
       </Box>
       {error && (
@@ -72,7 +74,7 @@ export default function ProjectPanel({ activeId, onSelect }) {
             onClick={() => onSelect && onSelect(p.id)}
             secondaryAction={
               <Button color="error" onClick={() => handleDelete(p.id)}>
-                Löschen
+                {t('delete')}
               </Button>
             }
           >

--- a/internal/ui/src/components/ProjectPanel.test.jsx
+++ b/internal/ui/src/components/ProjectPanel.test.jsx
@@ -2,6 +2,7 @@ import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import { vi, beforeEach } from 'vitest';
 import ProjectPanel from './ProjectPanel';
+import '../i18n';
 
 vi.mock('../wailsjs/go/service/DataService', () => ({
   ListProjects: vi.fn(),

--- a/internal/ui/src/components/TaxPanel.jsx
+++ b/internal/ui/src/components/TaxPanel.jsx
@@ -1,10 +1,12 @@
 import { useState } from "react";
 import { Box, Button, Typography } from "@mui/material";
+import { useTranslation } from "react-i18next";
 import { CalculateProjectTaxes } from "../wailsjs/go/service/DataService";
 
 export default function TaxPanel({ projectId }) {
   const [taxes, setTaxes] = useState(null);
   const [error, setError] = useState("");
+  const { t } = useTranslation();
 
   const handleCalculate = async () => {
     try {
@@ -12,21 +14,21 @@ export default function TaxPanel({ projectId }) {
       setTaxes(result);
       setError("");
     } catch (err) {
-      setError(err.message || "Fehler bei Berechnung");
+      setError(err.message || t('tax.error'));
     }
   };
 
   return (
     <Box>
       <Button variant="contained" color="secondary" onClick={handleCalculate}>
-        Steuern berechnen
+        {t('tax.calculate')}
       </Button>
       {taxes && (
         <Box sx={{ mt: 2 }}>
-          <Typography>Einnahmen: {taxes.revenue.toFixed(2)} €</Typography>
-          <Typography>Ausgaben: {taxes.expenses.toFixed(2)} €</Typography>
-          <Typography>Steuerpflichtiges Einkommen: {taxes.taxableIncome.toFixed(2)} €</Typography>
-          <Typography>Gesamtsteuer: {taxes.totalTax.toFixed(2)} €</Typography>
+          <Typography>{t('tax.revenue', { value: taxes.revenue.toFixed(2) })}</Typography>
+          <Typography>{t('tax.expenses', { value: taxes.expenses.toFixed(2) })}</Typography>
+          <Typography>{t('tax.taxableIncome', { value: taxes.taxableIncome.toFixed(2) })}</Typography>
+          <Typography>{t('tax.totalTax', { value: taxes.totalTax.toFixed(2) })}</Typography>
         </Box>
       )}
       {error && (

--- a/internal/ui/src/i18n.js
+++ b/internal/ui/src/i18n.js
@@ -1,0 +1,19 @@
+import i18n from 'i18next';
+import { initReactI18next } from 'react-i18next';
+import de from './locales/de.json' assert { type: 'json' };
+import en from './locales/en.json' assert { type: 'json' };
+
+i18n
+  .use(initReactI18next)
+  .init({
+    resources: {
+      de: { translation: de },
+      en: { translation: en },
+    },
+    lng: 'de',
+    fallbackLng: 'de',
+    initImmediate: false,
+    interpolation: { escapeValue: false },
+  });
+
+export default i18n;

--- a/internal/ui/src/locales/de.json
+++ b/internal/ui/src/locales/de.json
@@ -1,0 +1,69 @@
+{
+  "theme": {"dark": "Dunkel", "light": "Hell"},
+  "tab": {
+    "projects": "Projekte",
+    "incomes": "Einnahmen",
+    "expenses": "Ausgaben",
+    "forms": "Formulare",
+    "taxes": "Steuern"
+  },
+  "income": {
+    "new": "Neue Einnahme",
+    "add": "Hinzufügen",
+    "source": "Quelle",
+    "amount": "Betrag (€)",
+    "required": "Quelle und Betrag erforderlich",
+    "positive": "Betrag muss eine positive Zahl sein",
+    "table": {
+      "source": "Quelle",
+      "amount": "Betrag (€)",
+      "actions": "Aktionen",
+      "empty": "Keine Einnahmen vorhanden"
+    }
+  },
+  "expense": {
+    "new": "Neue Ausgabe",
+    "description": "Beschreibung",
+    "amount": "Betrag (€)",
+    "required": "Beschreibung und Betrag erforderlich",
+    "positive": "Betrag muss eine positive Zahl sein",
+    "table": {
+      "description": "Beschreibung",
+      "amount": "Betrag (€)",
+      "actions": "Aktionen",
+      "empty": "Keine Ausgaben vorhanden"
+    }
+  },
+  "project": {
+    "new": "Neues Projekt",
+    "create": "Erstellen",
+    "error": "Fehler beim Erstellen",
+    "delete": "Löschen"
+  },
+  "forms": {
+    "generate_all": "Alle Formulare erstellen",
+    "error": "Fehler beim Erstellen"
+  },
+  "form": {
+    "generate": "Erstellen",
+    "kst1": "KSt 1",
+    "anlageGem": "Anlage Gem",
+    "anlageGK": "Anlage GK",
+    "kst1f": "KSt 1F",
+    "anlageSport": "Anlage Sport"
+  },
+  "tax": {
+    "calculate": "Steuern berechnen",
+    "revenue": "Einnahmen: {{value}} €",
+    "expenses": "Ausgaben: {{value}} €",
+    "taxableIncome": "Steuerpflichtiges Einkommen: {{value}} €",
+    "totalTax": "Gesamtsteuer: {{value}} €",
+    "error": "Fehler bei Berechnung"
+  },
+  "language": "Sprache",
+  "language_de": "Deutsch",
+  "language_en": "Englisch",
+  "edit": "Bearbeiten",
+  "delete": "Löschen",
+  "add_error": "Fehler beim Hinzufügen"
+}

--- a/internal/ui/src/locales/en.json
+++ b/internal/ui/src/locales/en.json
@@ -1,0 +1,69 @@
+{
+  "theme": {"dark": "Dark", "light": "Light"},
+  "tab": {
+    "projects": "Projects",
+    "incomes": "Income",
+    "expenses": "Expenses",
+    "forms": "Forms",
+    "taxes": "Taxes"
+  },
+  "income": {
+    "new": "New Income",
+    "add": "Add",
+    "source": "Source",
+    "amount": "Amount (€)",
+    "required": "Source and amount required",
+    "positive": "Amount must be a positive number",
+    "table": {
+      "source": "Source",
+      "amount": "Amount (€)",
+      "actions": "Actions",
+      "empty": "No income recorded"
+    }
+  },
+  "expense": {
+    "new": "New Expense",
+    "description": "Description",
+    "amount": "Amount (€)",
+    "required": "Description and amount required",
+    "positive": "Amount must be a positive number",
+    "table": {
+      "description": "Description",
+      "amount": "Amount (€)",
+      "actions": "Actions",
+      "empty": "No expenses recorded"
+    }
+  },
+  "project": {
+    "new": "New Project",
+    "create": "Create",
+    "error": "Error creating",
+    "delete": "Delete"
+  },
+  "forms": {
+    "generate_all": "Generate All Forms",
+    "error": "Error generating"
+  },
+  "form": {
+    "generate": "Generate",
+    "kst1": "KSt 1",
+    "anlageGem": "Anlage Gem",
+    "anlageGK": "Anlage GK",
+    "kst1f": "KSt 1F",
+    "anlageSport": "Anlage Sport"
+  },
+  "tax": {
+    "calculate": "Calculate Taxes",
+    "revenue": "Revenue: {{value}} €",
+    "expenses": "Expenses: {{value}} €",
+    "taxableIncome": "Taxable income: {{value}} €",
+    "totalTax": "Total tax: {{value}} €",
+    "error": "Error calculating"
+  },
+  "language": "Language",
+  "language_de": "German",
+  "language_en": "English",
+  "edit": "Edit",
+  "delete": "Delete",
+  "add_error": "Error adding item"
+}


### PR DESCRIPTION
## Summary
- introduce `react-i18next` for translations
- provide German and English locale files
- add language selector to the toolbar
- translate UI components
- document language switching

## Testing
- `go work sync`
- `go test ./cmd/... ./internal/... ./internal/pdf/...` *(fails: build errors)*
- `npm test --prefix internal/ui` *(fails: unable to find button with text "Hinzufügen")*

------
https://chatgpt.com/codex/tasks/task_e_68681a40edcc8333915662a2121a8f38