### PR TITLE
Improve logging with context and JSON option

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -49,7 +49,7 @@ func main() {
 		return
 	}
 
-	logger, logCloser := service.NewLogger(cfg.LogFile, cfg.LogLevel)
+	logger, logCloser := service.NewLogger(cfg.LogFile, cfg.LogLevel, cfg.LogFormat)
 	generator := pdf.NewGenerator(cfg.PDFDir, store)
 	datasvc := service.NewDataServiceFromStore(store, logger, logCloser)
 	defer datasvc.Close()

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -8,10 +8,11 @@ import (
 
 // Config holds application configuration values.
 type Config struct {
-	DBPath   string `json:"dbPath"`
-	PDFDir   string `json:"pdfDir"`
-	LogFile  string `json:"logFile"`
-	LogLevel string `json:"logLevel"`
+	DBPath    string `json:"dbPath"`
+	PDFDir    string `json:"pdfDir"`
+	LogFile   string `json:"logFile"`
+	LogLevel  string `json:"logLevel"`
+	LogFormat string `json:"logFormat"`
 }
 
 // Load reads configuration from the given file path. If the file does not exist,

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -14,7 +14,8 @@ func TestLoadFromFile(t *testing.T) {
         "dbPath": "db.sqlite",
         "pdfDir": "./pdfs",
         "logFile": "app.log",
-        "logLevel": "debug"
+        "logLevel": "debug",
+        "logFormat": "json"
     }`
 	if err := os.WriteFile(path, []byte(data), 0o644); err != nil {
 		t.Fatal(err)
@@ -24,7 +25,7 @@ func TestLoadFromFile(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Load returned error: %v", err)
 	}
-	if cfg.DBPath != "db.sqlite" || cfg.PDFDir != "./pdfs" || cfg.LogFile != "app.log" || cfg.LogLevel != "debug" {
+	if cfg.DBPath != "db.sqlite" || cfg.PDFDir != "./pdfs" || cfg.LogFile != "app.log" || cfg.LogLevel != "debug" || cfg.LogFormat != "json" {
 		t.Fatalf("unexpected config: %+v", cfg)
 	}
 }
@@ -45,7 +46,7 @@ func TestLoadMissingFile(t *testing.T) {
 func TestSaveAndVerify(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "out.json")
-	expected := Config{DBPath: "db", PDFDir: "pdf", LogFile: "log", LogLevel: "info"}
+	expected := Config{DBPath: "db", PDFDir: "pdf", LogFile: "log", LogLevel: "info", LogFormat: "json"}
 
 	if err := Save(path, expected); err != nil {
 		t.Fatalf("Save returned error: %v", err)

--- a/internal/service/service_test.go
+++ b/internal/service/service_test.go
@@ -247,7 +247,8 @@ func TestDataService_ProjectOperations(t *testing.T) {
 	}
 	defer ds.Close()
 
-	p, err := ds.CreateProject("Proj1")
+	ctx := context.Background()
+	p, err := ds.CreateProject(ctx, "Proj1")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -316,7 +317,7 @@ func TestValidateAmount(t *testing.T) {
 func TestDataService_LoggerClosed(t *testing.T) {
 	tmpDir := t.TempDir()
 	logPath := filepath.Join(tmpDir, "app.log")
-	logger, closer := NewLogger(logPath, "info")
+	logger, closer := NewLogger(logPath, "info", "text")
 	if closer == nil {
 		t.Fatalf("expected closer for log file")
 	}


### PR DESCRIPTION
## Summary
- add `LogFormat` to config and allow json/text log output
- wrap service errors with log messages
- add error logging to PDF generator
- support json log handler in logger
- fix tests for updated API

## Testing
- `go test ./cmd/... ./internal/... ./internal/pdf/...`

------
https://chatgpt.com/codex/tasks/task_e_68681a42965c83338d8f9f21fb9398bd