### PR TITLE
Add release automation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,115 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - '*'
+
+jobs:
+  package:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.22.x'
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: '18'
+          cache: 'npm'
+          cache-dependency-path: internal/ui/package-lock.json
+
+      - name: Install Wails CLI
+        run: go install github.com/wailsapp/wails/v2/cmd/wails@latest
+
+      - name: Install Go dependencies
+        run: go mod tidy
+
+      - name: Install frontend dependencies
+        run: npm ci
+        working-directory: internal/ui
+
+      - name: Build packages
+        run: ./scripts/package.sh ${{ github.ref_name }}
+
+      - name: Archive packages
+        run: |
+          VERSION="${{ github.ref_name }}"
+          cd build/bin/"$VERSION"
+          for dir in */; do
+            zip -r "../baristeuer-${dir%/}-${VERSION}.zip" "$dir"
+          done
+
+      - name: Generate checksums
+        run: |
+          VERSION="${{ github.ref_name }}"
+          cd build/bin
+          sha256sum baristeuer-*-${VERSION}.zip > SHA256SUMS
+
+      - name: Import GPG signing key
+        env:
+          GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
+        run: |
+          echo "$GPG_PRIVATE_KEY" | gpg --batch --import
+
+      - name: Sign checksums
+        run: |
+          gpg --batch --yes --armor --output build/bin/SHA256SUMS.sig --detach-sign build/bin/SHA256SUMS
+
+      - name: Create Release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.ref_name }}
+          release_name: ${{ github.ref_name }}
+          draft: false
+          prerelease: false
+
+      - name: Upload Linux package
+        uses: actions/upload-release-asset@v1
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: build/bin/baristeuer-linux-${{ github.ref_name }}.zip
+          asset_name: baristeuer-linux-${{ github.ref_name }}.zip
+          asset_content_type: application/zip
+
+      - name: Upload macOS package
+        uses: actions/upload-release-asset@v1
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: build/bin/baristeuer-macos-${{ github.ref_name }}.zip
+          asset_name: baristeuer-macos-${{ github.ref_name }}.zip
+          asset_content_type: application/zip
+
+      - name: Upload Windows package
+        uses: actions/upload-release-asset@v1
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: build/bin/baristeuer-windows-${{ github.ref_name }}.zip
+          asset_name: baristeuer-windows-${{ github.ref_name }}.zip
+          asset_content_type: application/zip
+
+      - name: Upload checksums
+        uses: actions/upload-release-asset@v1
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: build/bin/SHA256SUMS
+          asset_name: SHA256SUMS
+          asset_content_type: text/plain
+
+      - name: Upload signature
+        uses: actions/upload-release-asset@v1
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: build/bin/SHA256SUMS.sig
+          asset_name: SHA256SUMS.sig
+          asset_content_type: application/pgp-signature


### PR DESCRIPTION
## Summary
- trigger packaging script on tag push
- publish zipped artifacts and signed checksums as a GitHub release

## Testing
- `go work sync`
- `go test ./cmd/... ./internal/... ./internal/pdf/...` *(fails: not enough arguments in calls)*
- `npm ci --prefix internal/ui`
- `npm test --prefix internal/ui --if-present`


------
https://chatgpt.com/codex/tasks/task_e_68681a432af08333952c3555df4a5601