### PR TITLE
Add missing project panel tests

### DIFF
--- a/internal/ui/src/components/ProjectPanel.test.jsx
+++ b/internal/ui/src/components/ProjectPanel.test.jsx
@@ -28,4 +28,36 @@ test('selects a project', async () => {
   expect(onSelect).toHaveBeenCalledWith(2);
 });
 
+test('creates a project and shows it in the list', async () => {
+  ListProjects
+    .mockResolvedValueOnce([])
+    .mockResolvedValueOnce([{ id: 1, name: 'Foo' }]);
+  CreateProject.mockResolvedValueOnce({ id: 1, name: 'Foo' });
+  const onSelect = vi.fn();
+  render(<ProjectPanel activeId={0} onSelect={onSelect} />);
+  await screen.findByRole('textbox', { name: /Neues Projekt/i });
+  fireEvent.change(screen.getByLabelText(/Neues Projekt/i), { target: { value: 'Foo' } });
+  fireEvent.click(screen.getByRole('button', { name: /Erstellen/i }));
+
+  await waitFor(() => expect(CreateProject).toHaveBeenCalledWith('Foo'));
+  expect(await screen.findByText('Foo')).toBeInTheDocument();
+  expect(onSelect).toHaveBeenCalledWith(1);
+});
+
+test('deletes a project', async () => {
+  ListProjects
+    .mockResolvedValueOnce([
+      { id: 1, name: 'Alpha' },
+      { id: 2, name: 'Beta' },
+    ])
+    .mockResolvedValueOnce([{ id: 2, name: 'Beta' }]);
+  DeleteProject.mockResolvedValueOnce();
+  render(<ProjectPanel activeId={1} />);
+  await screen.findByText('Alpha');
+  fireEvent.click(screen.getAllByRole('button', { name: /Löschen/i })[0]);
+
+  await waitFor(() => expect(DeleteProject).toHaveBeenCalledWith(1));
+  await waitFor(() => expect(screen.queryByText('Alpha')).not.toBeInTheDocument());
+});
+
 

--- a/internal/ui/src/locales/de.json
+++ b/internal/ui/src/locales/de.json
@@ -23,6 +23,7 @@
   },
   "expense": {
     "new": "Neue Ausgabe",
+    "add": "Hinzufügen",
     "description": "Beschreibung",
     "amount": "Betrag (€)",
     "required": "Beschreibung und Betrag erforderlich",

--- a/internal/ui/src/locales/en.json
+++ b/internal/ui/src/locales/en.json
@@ -23,6 +23,7 @@
   },
   "expense": {
     "new": "New Expense",
+    "add": "Add",
     "description": "Description",
     "amount": "Amount (€)",
     "required": "Description and amount required",


### PR DESCRIPTION
## Summary
- extend ProjectPanel tests for creating and deleting projects
- add missing translation keys for expense add button

## Testing
- `npm test --prefix internal/ui`

------
https://chatgpt.com/codex/tasks/task_e_68683ca89fa483338492c617f52656a5