### PR TITLE
Fix expense form translation

### DIFF
--- a/internal/ui/src/locales/de.json
+++ b/internal/ui/src/locales/de.json
@@ -25,6 +25,7 @@
     "new": "Neue Ausgabe",
     "description": "Beschreibung",
     "amount": "Betrag (€)",
+    "add": "Hinzufügen",
     "required": "Beschreibung und Betrag erforderlich",
     "positive": "Betrag muss eine positive Zahl sein",
     "table": {

--- a/internal/ui/src/locales/en.json
+++ b/internal/ui/src/locales/en.json
@@ -25,6 +25,7 @@
     "new": "New Expense",
     "description": "Description",
     "amount": "Amount (€)",
+    "add": "Add",
     "required": "Description and amount required",
     "positive": "Amount must be a positive number",
     "table": {


### PR DESCRIPTION
## Summary
- add missing `expense.add` translation in both locale files
- ensure expense tests pass with correct text

## Testing
- `npm test --silent` in `internal/ui`
- `go test ./cmd/... ./internal/... ./internal/pdf/...`


------
https://chatgpt.com/codex/tasks/task_e_68683ca99dc0833392ab32286b4f7adc