### PR TITLE
Add Makefile for test and lint tasks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,15 @@
+.PHONY: vet go-test lint ui-test test
+
+vet:
+	go vet ./cmd/... ./internal/... ./internal/pdf/...
+
+go-test:
+	go test ./cmd/... ./internal/... ./internal/pdf/...
+
+lint:
+	npm run lint --prefix internal/ui
+
+ui-test:
+	npm test --prefix internal/ui
+
+test: go-test ui-test

--- a/README.md
+++ b/README.md
@@ -72,6 +72,18 @@ Follow the official documentation for platform specific details.
 
 See [docs/DOCUMENTATION.md](docs/DOCUMENTATION.md) for more details.
 
+## Makefile
+
+Common development commands are collected in a small Makefile:
+
+```bash
+make vet       # run go vet
+make go-test   # run Go tests
+make lint      # lint the UI
+make ui-test   # run frontend tests
+make test      # run Go and UI tests
+```
+
 ## Packaging
 
 Run the packaging script to build binaries for macOS, Windows and Linux and place them


### PR DESCRIPTION
## Summary
- add a Makefile with tasks for Go vet/test and UI lint/test
- document how to use the Makefile in the README

## Testing
- `make vet`
- `make go-test`
- `make lint` *(fails: eslint errors)*
- `make ui-test`


------
https://chatgpt.com/codex/tasks/task_e_686912097d4c8333adb79af9de0359f2