### PR TITLE
Update go directives in internal modules

### DIFF
--- a/internal/go.mod
+++ b/internal/go.mod
@@ -1,6 +1,6 @@
 module baristeuer/internal
 
-go 1.20
+go 1.22
 
 require (
 	github.com/mattn/go-sqlite3 v1.14.28

--- a/internal/pdf/go.mod
+++ b/internal/pdf/go.mod
@@ -1,5 +1,5 @@
 module baristeuer/internal/pdf
 
-go 1.20
+go 1.22
 
 require github.com/jung-kurt/gofpdf v1.16.2


### PR DESCRIPTION
## Summary
- sync go directives with cmd module by bumping `internal` and `internal/pdf` to Go 1.22

## Testing
- `go test ./internal/... ./internal/pdf`

------
https://chatgpt.com/codex/tasks/task_e_686912092a5c8333b4291d78cc06c091