### PR TITLE
Fix duplicate keys and add tax year translations

### DIFF
--- a/internal/ui/src/locales/de.json
+++ b/internal/ui/src/locales/de.json
@@ -26,7 +26,6 @@
     "add": "Hinzufügen",
     "description": "Beschreibung",
     "amount": "Betrag (€)",
-    "add": "Hinzufügen",
     "required": "Beschreibung und Betrag erforderlich",
     "positive": "Betrag muss eine positive Zahl sein",
     "table": {
@@ -60,6 +59,7 @@
     "expenses": "Ausgaben: {{value}} €",
     "taxableIncome": "Steuerpflichtiges Einkommen: {{value}} €",
     "totalTax": "Gesamtsteuer: {{value}} €",
+    "year": "Jahr",
     "error": "Fehler bei Berechnung"
   },
   "language": "Sprache",

--- a/internal/ui/src/locales/en.json
+++ b/internal/ui/src/locales/en.json
@@ -26,7 +26,6 @@
     "add": "Add",
     "description": "Description",
     "amount": "Amount (€)",
-    "add": "Add",
     "required": "Description and amount required",
     "positive": "Amount must be a positive number",
     "table": {
@@ -60,6 +59,7 @@
     "expenses": "Expenses: {{value}} €",
     "taxableIncome": "Taxable income: {{value}} €",
     "totalTax": "Total tax: {{value}} €",
+    "year": "Year",
     "error": "Error calculating"
   },
   "language": "Language",


### PR DESCRIPTION
## Summary
- remove duplicate `add` entry in German and English locale files
- add missing `year` translation for tax sections

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6869120670c083338cc02498e4a59d65