### PR TITLE
Add Playwright e2e tests

### DIFF
--- a/internal/ui/e2e/mockDataService.js
+++ b/internal/ui/e2e/mockDataService.js
@@ -1,0 +1,60 @@
+(() => {
+  const projects = [];
+  const incomes = {};
+  const expenses = {};
+  function ensure(pid, map) {
+    if (!map[pid]) map[pid] = [];
+    return map[pid];
+  }
+  window.go = { service: { DataService: {} } };
+  const svc = window.go.service.DataService;
+  svc.ListProjects = async () => projects;
+  svc.CreateProject = async (name) => {
+    const id = projects.length + 1;
+    const p = { id, name };
+    projects.push(p);
+    return p;
+  };
+  svc.DeleteProject = async (id) => {
+    const i = projects.findIndex((p) => p.id === id);
+    if (i > -1) projects.splice(i, 1);
+    delete incomes[id];
+    delete expenses[id];
+  };
+  svc.ListIncomes = async (pid) => ensure(pid, incomes);
+  svc.AddIncome = async (pid, source, amount) => {
+    const list = ensure(pid, incomes);
+    const id = list.length + 1;
+    const it = { id, source, amount };
+    list.push(it);
+    return it;
+  };
+  svc.DeleteIncome = async (id) => {
+    for (const pid of Object.keys(incomes)) {
+      const list = incomes[pid];
+      const idx = list.findIndex((i) => i.id === id);
+      if (idx > -1) {
+        list.splice(idx, 1);
+        break;
+      }
+    }
+  };
+  svc.ListExpenses = async (pid) => ensure(pid, expenses);
+  svc.AddExpense = async (pid, desc, amount) => {
+    const list = ensure(pid, expenses);
+    const id = list.length + 1;
+    const it = { id, description: desc, amount };
+    list.push(it);
+    return it;
+  };
+  svc.DeleteExpense = async (id) => {
+    for (const pid of Object.keys(expenses)) {
+      const list = expenses[pid];
+      const idx = list.findIndex((e) => e.id === id);
+      if (idx > -1) {
+        list.splice(idx, 1);
+        break;
+      }
+    }
+  };
+})();

--- a/internal/ui/e2e/project.spec.js
+++ b/internal/ui/e2e/project.spec.js
@@ -1,0 +1,39 @@
+import { test, expect } from "@playwright/test";
+import { fileURLToPath } from "url";
+import path from "path";
+
+test.beforeEach(async ({ page }) => {
+  const dir = path.dirname(fileURLToPath(import.meta.url));
+  const scriptPath = path.join(dir, "mockDataService.js");
+  await page.addInitScript({ path: scriptPath });
+});
+
+test("create project and manage income and expenses", async ({ page }) => {
+  await page.goto("/");
+
+  await page.getByRole("textbox", { name: /Neues Projekt/i }).fill("Demo");
+  await page.getByRole("button", { name: /Erstellen/i }).click();
+  await expect(page.getByText("Demo")).toBeVisible();
+
+  await page.getByRole("tab", { name: /Einnahmen/i }).click();
+  await page.getByLabel("Quelle").fill("Spende");
+  await page.getByLabel("Betrag").fill("10");
+  await page.getByRole("button", { name: /Hinzufügen/i }).click();
+  await expect(page.getByText("Spende")).toBeVisible();
+  await page
+    .getByRole("button", { name: /Löschen/i })
+    .first()
+    .click();
+  await expect(page.getByText("Spende")).not.toBeVisible();
+
+  await page.getByRole("tab", { name: /Ausgaben/i }).click();
+  await page.getByLabel("Beschreibung").fill("Miete");
+  await page.getByLabel(/^Betrag/).fill("5");
+  await page.getByRole("button", { name: /Hinzufügen/i }).click();
+  await expect(page.getByText("Miete")).toBeVisible();
+  await page
+    .getByRole("button", { name: /Löschen/i })
+    .first()
+    .click();
+  await expect(page.getByText("Miete")).not.toBeVisible();
+});

--- a/internal/ui/package-lock.json
+++ b/internal/ui/package-lock.json
@@ -18,6 +18,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.30.1",
+        "@playwright/test": "^1.43.1",
         "@testing-library/jest-dom": "^6.6.3",
         "@testing-library/react": "^16.3.0",
         "@types/react": "^19.1.8",
@@ -1524,6 +1525,23 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.1.0.tgz",
       "integrity": "sha512-Oe56aUPnkHyyDxxkvqtd7KkdQP5uIUfHxd5XTb3wE9d/kRnZLmKbDB0GWk919tdQ+mxxPtG6EAs6RMT6i1qtHg==",
       "license": "MIT"
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.43.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.43.1.tgz",
+      "integrity": "sha512-HgtQzFgNEEo4TE22K/X7sYTYNqEMMTZmFS8kTq6m8hXj+m1D8TgwgIbumHddJa9h4yl4GkKb8/bgAl2+g7eDgA==",
+      "deprecated": "Please update to the latest version of Playwright to test up-to-date browsers.",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.43.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=16"
+      }
     },
     "node_modules/@popperjs/core": {
       "version": "2.11.8",
@@ -4033,6 +4051,53 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.43.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.43.1.tgz",
+      "integrity": "sha512-V7SoH0ai2kNt1Md9E3Gwas5B9m8KR2GVvwZnAI6Pg0m3sh7UvgiYhRrhsziCmqMJNouPckiOhk8T+9bSAK0VIA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.43.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.43.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.43.1.tgz",
+      "integrity": "sha512-EI36Mto2Vrx6VF7rm708qSnesVQKbxEWvPrfA1IPY6HgczBplDx7ENtx+K2n4kJ41sLLkuGfmb0ZLSSXlDhqPg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/postcss": {

--- a/internal/ui/package.json
+++ b/internal/ui/package.json
@@ -9,19 +9,21 @@
     "lint": "eslint .",
     "preview": "vite preview",
     "start": "vite",
-    "test": "vitest --run"
+    "test": "vitest --run",
+    "test:e2e": "playwright test"
   },
   "dependencies": {
     "@emotion/react": "^11.14.0",
     "@emotion/styled": "^11.14.1",
     "@mui/material": "^5.15.8",
+    "i18next": "^23.10.0",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
-    "i18next": "^23.10.0",
     "react-i18next": "^13.2.1"
   },
   "devDependencies": {
     "@eslint/js": "^9.30.1",
+    "@playwright/test": "^1.43.1",
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.3.0",
     "@types/react": "^19.1.8",

--- a/internal/ui/playwright.config.js
+++ b/internal/ui/playwright.config.js
@@ -1,0 +1,16 @@
+import { defineConfig } from "@playwright/test";
+
+export default defineConfig({
+  testDir: "./e2e",
+  timeout: 30000,
+  use: {
+    baseURL: "http://localhost:5173",
+    headless: true,
+  },
+  webServer: {
+    command: "npm run dev",
+    port: 5173,
+    reuseExistingServer: !process.env.CI,
+    timeout: 120 * 1000,
+  },
+});

--- a/internal/ui/vite.config.js
+++ b/internal/ui/vite.config.js
@@ -1,5 +1,6 @@
-import { defineConfig } from 'vite'
-import react from '@vitejs/plugin-react'
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
+import { configDefaults } from "vitest/config";
 
 // https://vite.dev/config/
 export default defineConfig({
@@ -9,7 +10,8 @@ export default defineConfig({
   css: {},
   plugins: [react()],
   test: {
-    environment: 'jsdom',
+    environment: "jsdom",
     globals: true,
+    exclude: [...configDefaults.exclude, "e2e/**"],
   },
-})
+});


### PR DESCRIPTION
## Summary
- configure Playwright for UI e2e tests
- stub Wails data service for browser tests
- write test covering project creation and income/expense management
- exclude e2e folder from Vitest

## Testing
- `npm run build` in `internal/ui`
- `npm test` in `internal/ui`
- `npm run test:e2e` *(fails: Test timeout of 30000ms exceeded)*
- `go build ./cmd/... ./internal/... ./internal/pdf/...`

------
https://chatgpt.com/codex/tasks/task_e_6869120fad54833385d879bfaad97016