### PR TITLE
Add exportdb flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,12 @@ The resulting binaries can be found in `build/bin`. You can configure paths via 
 ./baristeuer -db mydata.db -pdfdir ./reports
 ```
 
+To export the current database without starting the UI, call the binary with `-exportdb` and a target path:
+
+```bash
+./baristeuer -exportdb backup.db
+```
+
 A minimal `config.json` might look like:
 
 ```json

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -18,6 +18,7 @@ func main() {
 	pdfDir := flag.String("pdfdir", "", "directory for generated PDFs")
 	logFile := flag.String("logfile", "", "log file path")
 	logLevel := flag.String("loglevel", "", "log level")
+	exportPath := flag.String("exportdb", "", "export database to path and exit")
 	flag.Parse()
 
 	cfg, err := config.Load(*cfgPath)
@@ -53,6 +54,13 @@ func main() {
 	generator := pdf.NewGenerator(cfg.PDFDir, store)
 	datasvc := service.NewDataServiceFromStore(store, logger, logCloser)
 	defer datasvc.Close()
+
+	if *exportPath != "" {
+		if err := datasvc.ExportDatabase(*exportPath); err != nil {
+			fmt.Println("Error exporting database:", err)
+		}
+		return
+	}
 
 	err = wails.Run(&options.App{
 		Title:       "Baristeuer",


### PR DESCRIPTION
## Summary
- add `-exportdb` flag to export database and quit
- document database export option in README

## Testing
- `go work sync`
- `go test ./cmd/... ./internal/... ./internal/pdf/...`
- `npm ci --prefix internal/ui`
- `npm test --prefix internal/ui`


------
https://chatgpt.com/codex/tasks/task_e_68692779885483339a9571ccec914cb2