### PR TITLE
Add member management UI

### DIFF
--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -197,12 +197,21 @@ func (ds *DataService) AddMember(ctx context.Context, name, email, joinDate stri
 
 // ListMembers returns all members sorted by name.
 func (ds *DataService) ListMembers(ctx context.Context) ([]data.Member, error) {
-	members, err := ds.store.ListMembers(ctx)
-	if err != nil {
-		return nil, fmt.Errorf("list members: %w", err)
-	}
-	ds.logger.Info("listed members", "count", len(members))
-	return members, nil
+        members, err := ds.store.ListMembers(ctx)
+        if err != nil {
+                return nil, fmt.Errorf("list members: %w", err)
+        }
+        ds.logger.Info("listed members", "count", len(members))
+        return members, nil
+}
+
+// DeleteMember removes a member by ID.
+func (ds *DataService) DeleteMember(ctx context.Context, id int64) error {
+        if err := ds.store.DeleteMember(ctx, id); err != nil {
+                return fmt.Errorf("delete member: %w", err)
+        }
+        ds.logger.Info("deleted member", "id", id)
+        return nil
 }
 
 // CalculateProjectTaxes returns a detailed tax calculation for the given project.

--- a/internal/ui/src/App.jsx
+++ b/internal/ui/src/App.jsx
@@ -3,22 +3,25 @@ import { ThemeProvider, createTheme } from "@mui/material/styles";
 import { CssBaseline, Container, FormControlLabel, Switch, AppBar, Toolbar, Typography, Tabs, Tab, Paper, Select, MenuItem } from "@mui/material";
 import { useTranslation } from "react-i18next";
 import "./i18n";
-import { ListExpenses, ListIncomes, AddIncome, UpdateIncome, DeleteIncome, AddExpense, UpdateExpense, DeleteExpense } from "./wailsjs/go/service/DataService";
+import { ListExpenses, ListIncomes, AddIncome, UpdateIncome, DeleteIncome, AddExpense, UpdateExpense, DeleteExpense, AddMember, ListMembers, DeleteMember } from "./wailsjs/go/service/DataService";
 import ProjectPanel from "./components/ProjectPanel";
 import IncomeForm from "./components/IncomeForm";
 import IncomeTable from "./components/IncomeTable";
 import ExpenseForm from "./components/ExpenseForm";
 import ExpenseTable from "./components/ExpenseTable";
+import MemberForm from "./components/MemberForm";
+import MemberTable from "./components/MemberTable";
 import TaxPanel from "./components/TaxPanel";
 import FormsPanel from "./components/FormsPanel";
 
 export default function App() {
   const [incomes, setIncomes] = useState([]);
   const [expenses, setExpenses] = useState([]);
+  const [members, setMembers] = useState([]);
   const [editIncome, setEditIncome] = useState(null);
   const [editExpense, setEditExpense] = useState(null);
   const [darkMode, setDarkMode] = useState(false);
-  const [tab, setTab] = useState(1);
+  const [tab, setTab] = useState(2);
   const [projectId, setProjectId] = useState(1);
   const { t, i18n } = useTranslation();
   const [language, setLanguage] = useState(i18n.language);
@@ -39,6 +42,10 @@ export default function App() {
     const list = await ListIncomes(projectId);
     setIncomes(list || []);
   };
+  const fetchMembers = async () => {
+    const list = await ListMembers();
+    setMembers(list || []);
+  };
 
   const handleLanguageChange = (e) => {
     const lng = e.target.value;
@@ -50,6 +57,9 @@ export default function App() {
     fetchExpenses();
     fetchIncomes();
   }, [projectId]);
+  useEffect(() => {
+    fetchMembers();
+  }, []);
 
   const submitIncome = async (source, amount, setError) => {
     try {
@@ -81,6 +91,16 @@ export default function App() {
     }
   };
 
+  const submitMember = async (name, email, joinDate, setError) => {
+    try {
+      await AddMember(name, email, joinDate);
+      setError("");
+      fetchMembers();
+    } catch (err) {
+      setError(err.message || t('add_error'));
+    }
+  };
+
   return (
     <ThemeProvider theme={theme}>
       <CssBaseline />
@@ -106,6 +126,7 @@ export default function App() {
         </Toolbar>
         <Tabs value={tab} onChange={(_, v) => setTab(v)} textColor="inherit" indicatorColor="secondary" centered>
           <Tab label={t('tab.projects')} />
+          <Tab label={t('tab.members')} />
           <Tab label={t('tab.incomes')} />
           <Tab label={t('tab.expenses')} />
           <Tab label={t('tab.forms')} />
@@ -117,6 +138,25 @@ export default function App() {
           <ProjectPanel activeId={projectId} onSelect={(id) => setProjectId(id)} />
         )}
         {tab === 1 && (
+          <>
+            <Paper sx={{ p: 3, mb: 4 }}>
+              <Typography variant="h6" component="h2" gutterBottom>
+                {t('member.new')}
+              </Typography>
+              <MemberForm onSubmit={submitMember} />
+            </Paper>
+            <Paper>
+              <MemberTable
+                members={members}
+                onDelete={async (id) => {
+                  await DeleteMember(id);
+                  fetchMembers();
+                }}
+              />
+            </Paper>
+          </>
+        )}
+        {tab === 2 && (
           <>
             <Paper sx={{ p: 3, mb: 4 }}>
               <Typography variant="h6" component="h2" gutterBottom>
@@ -136,7 +176,7 @@ export default function App() {
             </Paper>
           </>
         )}
-        {tab === 2 && (
+        {tab === 3 && (
           <>
             <Paper sx={{ p: 3, mb: 4 }}>
               <Typography variant="h6" component="h2" gutterBottom>
@@ -156,8 +196,8 @@ export default function App() {
             </Paper>
           </>
         )}
-        {tab === 3 && <FormsPanel projectId={projectId} />}
-        {tab === 4 && (
+        {tab === 4 && <FormsPanel projectId={projectId} />}
+        {tab === 5 && (
           <Paper sx={{ p: 3 }}>
             <TaxPanel projectId={projectId} />
           </Paper>

--- a/internal/ui/src/App.test.jsx
+++ b/internal/ui/src/App.test.jsx
@@ -19,6 +19,9 @@ vi.mock('./wailsjs/go/service/DataService', () => ({
   UpdateIncome: vi.fn(),
   DeleteIncome: vi.fn(),
   ListIncomes: vi.fn(),
+  AddMember: vi.fn(),
+  ListMembers: vi.fn(),
+  DeleteMember: vi.fn(),
   CalculateProjectTaxes: vi.fn(),
 }), { virtual: true });
 
@@ -37,6 +40,9 @@ import {
   UpdateIncome,
   DeleteIncome,
   ListIncomes,
+  AddMember,
+  ListMembers,
+  DeleteMember,
   CalculateProjectTaxes,
 } from './wailsjs/go/service/DataService';
 
@@ -47,6 +53,7 @@ beforeEach(() => {
 test('renders app heading', async () => {
   ListExpenses.mockResolvedValueOnce([]);
   ListIncomes.mockResolvedValueOnce([]);
+  ListMembers.mockResolvedValueOnce([]);
   render(<App />);
   expect(await screen.findByRole('heading', { name: /Baristeuer/i })).toBeInTheDocument();
 });
@@ -56,6 +63,7 @@ test('renders app heading', async () => {
 test('adds a new income', async () => {
   ListExpenses.mockResolvedValueOnce([]);
   ListIncomes.mockResolvedValueOnce([]).mockResolvedValueOnce([{ id: 1, source: 'Donation', amount: 50 }]);
+  ListMembers.mockResolvedValueOnce([]);
   AddIncome.mockResolvedValueOnce();
   render(<App />);
   await screen.findByRole('heading', { name: /Baristeuer/i });
@@ -74,6 +82,7 @@ test('adds a new income', async () => {
 test('shows error when adding income fails', async () => {
   ListExpenses.mockResolvedValueOnce([]);
   ListIncomes.mockResolvedValueOnce([]);
+  ListMembers.mockResolvedValueOnce([]);
   AddIncome.mockRejectedValueOnce(new Error('fail'));
   render(<App />);
   await screen.findByRole('heading', { name: /Baristeuer/i });
@@ -90,6 +99,7 @@ test('shows error when adding income fails', async () => {
 test('edits an income', async () => {
   ListExpenses.mockResolvedValueOnce([]);
   ListIncomes.mockResolvedValueOnce([{ id: 1, source: 'Old', amount: 10 }]).mockResolvedValueOnce([{ id: 1, source: 'New', amount: 20 }]);
+  ListMembers.mockResolvedValueOnce([]);
   UpdateIncome.mockResolvedValueOnce();
   render(<App />);
   await screen.findByText('Old');
@@ -108,6 +118,7 @@ test('edits an income', async () => {
 test('deletes an income', async () => {
   ListExpenses.mockResolvedValueOnce([]);
   ListIncomes.mockResolvedValueOnce([{ id: 1, source: 'Del', amount: 30 }]).mockResolvedValueOnce([]);
+  ListMembers.mockResolvedValueOnce([]);
   DeleteIncome.mockResolvedValueOnce();
   render(<App />);
   await screen.findByText('Del');
@@ -123,6 +134,7 @@ test('deletes an income', async () => {
 test('adds a new expense', async () => {
   ListIncomes.mockResolvedValueOnce([]);
   ListExpenses.mockResolvedValueOnce([]).mockResolvedValueOnce([{ id: 1, description: 'Rent', amount: 15 }]);
+  ListMembers.mockResolvedValueOnce([]);
   AddExpense.mockResolvedValueOnce();
   render(<App />);
   await screen.findByRole('heading', { name: /Baristeuer/i });
@@ -142,6 +154,7 @@ test('adds a new expense', async () => {
 test('edits an expense', async () => {
   ListIncomes.mockResolvedValueOnce([]);
   ListExpenses.mockResolvedValueOnce([{ id: 1, description: 'Coffee', amount: 3 }]).mockResolvedValueOnce([{ id: 1, description: 'Tea', amount: 4 }]);
+  ListMembers.mockResolvedValueOnce([]);
   UpdateExpense.mockResolvedValueOnce();
   render(<App />);
   await screen.findByRole('heading', { name: /Baristeuer/i });
@@ -162,6 +175,7 @@ test('edits an expense', async () => {
 test('deletes an expense', async () => {
   ListIncomes.mockResolvedValueOnce([]);
   ListExpenses.mockResolvedValueOnce([{ id: 1, description: 'Coffee', amount: 3 }]).mockResolvedValueOnce([]);
+  ListMembers.mockResolvedValueOnce([]);
   DeleteExpense.mockResolvedValueOnce();
   render(<App />);
   await screen.findByRole('heading', { name: /Baristeuer/i });
@@ -179,6 +193,7 @@ test('deletes an expense', async () => {
 test('shows tax calculation result', async () => {
   ListExpenses.mockResolvedValueOnce([]);
   ListIncomes.mockResolvedValueOnce([]);
+  ListMembers.mockResolvedValueOnce([]);
   CalculateProjectTaxes.mockResolvedValueOnce({ revenue: 100, expenses: 20, taxableIncome: 80, totalTax: 10 });
   render(<App />);
   await screen.findByRole('heading', { name: /Baristeuer/i });
@@ -190,4 +205,43 @@ test('shows tax calculation result', async () => {
   expect(screen.getByText('Ausgaben: 20.00 \u20AC')).toBeInTheDocument();
   expect(screen.getByText('Steuerpflichtiges Einkommen: 80.00 \u20AC')).toBeInTheDocument();
   expect(screen.getByText('Gesamtsteuer: 10.00 \u20AC')).toBeInTheDocument();
+});
+
+// Add member
+
+test('adds a new member', async () => {
+  ListExpenses.mockResolvedValueOnce([]);
+  ListIncomes.mockResolvedValueOnce([]);
+  ListMembers.mockResolvedValueOnce([]).mockResolvedValueOnce([{ id: 1, name: 'Alice', email: 'a@example.com', joinDate: '2024-01-10' }]);
+  AddMember.mockResolvedValueOnce();
+  render(<App />);
+  await screen.findByRole('heading', { name: /Baristeuer/i });
+
+  fireEvent.click(screen.getByRole('tab', { name: /Mitglieder/i }));
+  fireEvent.change(screen.getByLabelText(/Name/i), { target: { value: 'Alice' } });
+  fireEvent.change(screen.getByLabelText(/E-Mail/i), { target: { value: 'a@example.com' } });
+  fireEvent.change(screen.getByLabelText(/Beitrittsdatum/i), { target: { value: '2024-01-10' } });
+  fireEvent.click(screen.getByRole('button', { name: /Hinzufügen/i }));
+
+  await waitFor(() => expect(AddMember).toHaveBeenCalledWith('Alice', 'a@example.com', '2024-01-10'));
+  expect(await screen.findByText('Alice')).toBeInTheDocument();
+});
+
+// Delete member
+
+test('deletes a member', async () => {
+  ListExpenses.mockResolvedValueOnce([]);
+  ListIncomes.mockResolvedValueOnce([]);
+  ListMembers.mockResolvedValueOnce([{ id: 1, name: 'Bob', email: 'b@example.com', joinDate: '2024-01-05' }]).mockResolvedValueOnce([]);
+  DeleteMember.mockResolvedValueOnce();
+  render(<App />);
+  await screen.findByRole('heading', { name: /Baristeuer/i });
+
+  fireEvent.click(screen.getByRole('tab', { name: /Mitglieder/i }));
+  await screen.findByText('Bob');
+
+  fireEvent.click(screen.getByRole('button', { name: /Löschen/i }));
+
+  await waitFor(() => expect(DeleteMember).toHaveBeenCalledWith(1));
+  await waitFor(() => expect(screen.queryByText('Bob')).not.toBeInTheDocument());
 });

--- a/internal/ui/src/components/MemberForm.jsx
+++ b/internal/ui/src/components/MemberForm.jsx
@@ -1,0 +1,44 @@
+import { useState } from "react";
+import { Box, TextField, Button, Typography } from "@mui/material";
+import { useTranslation } from "react-i18next";
+
+export default function MemberForm({ onSubmit }) {
+  const { t } = useTranslation();
+  const [name, setName] = useState("");
+  const [email, setEmail] = useState("");
+  const [joinDate, setJoinDate] = useState("2024-01-01");
+  const [error, setError] = useState("");
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    if (!name || !email) {
+      setError(t('member.required'));
+      return;
+    }
+    await onSubmit(name, email, joinDate, setError);
+    setName("");
+    setEmail("");
+  };
+
+  return (
+    <Box component="form" onSubmit={handleSubmit} display="flex" gap={2} flexWrap="wrap">
+      <TextField label={t('member.name')} value={name} onChange={(e) => setName(e.target.value)} fullWidth />
+      <TextField label={t('member.email')} value={email} onChange={(e) => setEmail(e.target.value)} fullWidth />
+      <TextField
+        label={t('member.joinDate')}
+        type="date"
+        value={joinDate}
+        onChange={(e) => setJoinDate(e.target.value)}
+        InputLabelProps={{ shrink: true }}
+      />
+      <Button type="submit" variant="contained">
+        {t('member.add')}
+      </Button>
+      {error && (
+        <Typography color="error" sx={{ mt: 2 }}>
+          {error}
+        </Typography>
+      )}
+    </Box>
+  );
+}

--- a/internal/ui/src/components/MemberTable.jsx
+++ b/internal/ui/src/components/MemberTable.jsx
@@ -1,0 +1,40 @@
+import { Table, TableHead, TableBody, TableRow, TableCell, Button } from "@mui/material";
+import { useTranslation } from "react-i18next";
+
+export default function MemberTable({ members, onDelete }) {
+  const { t } = useTranslation();
+  return (
+    <Table>
+      <TableHead>
+        <TableRow>
+          <TableCell>{t('member.table.name')}</TableCell>
+          <TableCell>{t('member.table.email')}</TableCell>
+          <TableCell>{t('member.table.joinDate')}</TableCell>
+          <TableCell>{t('member.table.actions')}</TableCell>
+        </TableRow>
+      </TableHead>
+      <TableBody>
+        {members.length > 0 ? (
+          members.map((m) => (
+            <TableRow key={m.id} hover>
+              <TableCell>{m.name}</TableCell>
+              <TableCell>{m.email}</TableCell>
+              <TableCell>{m.joinDate}</TableCell>
+              <TableCell>
+                <Button size="small" color="error" onClick={() => onDelete(m.id)}>
+                  {t('delete')}
+                </Button>
+              </TableCell>
+            </TableRow>
+          ))
+        ) : (
+          <TableRow>
+            <TableCell colSpan={4} align="center">
+              {t('member.table.empty')}
+            </TableCell>
+          </TableRow>
+        )}
+      </TableBody>
+    </Table>
+  );
+}

--- a/internal/ui/src/locales/de.json
+++ b/internal/ui/src/locales/de.json
@@ -2,6 +2,7 @@
   "theme": {"dark": "Dunkel", "light": "Hell"},
   "tab": {
     "projects": "Projekte",
+    "members": "Mitglieder",
     "incomes": "Einnahmen",
     "expenses": "Ausgaben",
     "forms": "Formulare",
@@ -40,6 +41,21 @@
     "create": "Erstellen",
     "error": "Fehler beim Erstellen",
     "delete": "Löschen"
+  },
+  "member": {
+    "new": "Neues Mitglied",
+    "add": "Hinzufügen",
+    "name": "Name",
+    "email": "E-Mail",
+    "joinDate": "Beitrittsdatum",
+    "required": "Name und E-Mail erforderlich",
+    "table": {
+      "name": "Name",
+      "email": "E-Mail",
+      "joinDate": "Beitrittsdatum",
+      "actions": "Aktionen",
+      "empty": "Keine Mitglieder vorhanden"
+    }
   },
   "forms": {
     "generate_all": "Alle Formulare erstellen",

--- a/internal/ui/src/locales/en.json
+++ b/internal/ui/src/locales/en.json
@@ -2,6 +2,7 @@
   "theme": {"dark": "Dark", "light": "Light"},
   "tab": {
     "projects": "Projects",
+    "members": "Members",
     "incomes": "Income",
     "expenses": "Expenses",
     "forms": "Forms",
@@ -40,6 +41,21 @@
     "create": "Create",
     "error": "Error creating",
     "delete": "Delete"
+  },
+  "member": {
+    "new": "New Member",
+    "add": "Add",
+    "name": "Name",
+    "email": "Email",
+    "joinDate": "Join Date",
+    "required": "Name and email required",
+    "table": {
+      "name": "Name",
+      "email": "Email",
+      "joinDate": "Join Date",
+      "actions": "Actions",
+      "empty": "No members recorded"
+    }
   },
   "forms": {
     "generate_all": "Generate All Forms",

--- a/internal/ui/src/wailsjs/go/service/DataService.js
+++ b/internal/ui/src/wailsjs/go/service/DataService.js
@@ -57,3 +57,15 @@ export function ListIncomes(arg1) {
 export function CalculateProjectTaxes(arg1, arg2) {
   return window.go.service.DataService.CalculateProjectTaxes(arg1, arg2);
 }
+
+export function AddMember(arg1, arg2, arg3) {
+  return window.go.service.DataService.AddMember(arg1, arg2, arg3);
+}
+
+export function ListMembers() {
+  return window.go.service.DataService.ListMembers();
+}
+
+export function DeleteMember(arg1) {
+  return window.go.service.DataService.DeleteMember(arg1);
+}


### PR DESCRIPTION
## Summary
- add MemberForm and MemberTable components
- include member handling in App with new "Mitglieder" tab
- extend i18n with member strings
- expose AddMember/ListMembers/DeleteMember bindings
- add tests for member CRUD via App
- add DeleteMember to Go service

## Testing
- `make go-test`
- `npm test --prefix internal/ui`

------
https://chatgpt.com/codex/tasks/task_e_686927787c1c8333ab8ab71e1e091930