### PR TITLE
Add English UI switch test

### DIFF
--- a/internal/ui/e2e/language.spec.js
+++ b/internal/ui/e2e/language.spec.js
@@ -1,0 +1,30 @@
+import { test, expect } from "@playwright/test";
+import { fileURLToPath } from "url";
+import path from "path";
+
+test.beforeEach(async ({ page }) => {
+  const dir = path.dirname(fileURLToPath(import.meta.url));
+  const scriptPath = path.join(dir, "mockDataService.js");
+  await page.addInitScript({ path: scriptPath });
+});
+
+test("switch UI language to English", async ({ page }) => {
+  await page.goto("/");
+
+  await page.getByRole("button", { name: "DE" }).click();
+  await page.getByRole("option", { name: "EN" }).click();
+
+  await expect(page.getByRole("tab", { name: "Projects" })).toBeVisible();
+  await expect(page.getByRole("tab", { name: "Income" })).toBeVisible();
+  await expect(page.getByRole("tab", { name: "Expenses" })).toBeVisible();
+
+  await page.getByRole("tab", { name: "Projects" }).click();
+  await expect(page.getByLabel("New Project")).toBeVisible();
+  await expect(page.getByRole("button", { name: "Create" })).toBeVisible();
+
+  await page.getByRole("tab", { name: "Income" }).click();
+  await expect(page.getByRole("heading", { name: "New Income" })).toBeVisible();
+  await expect(page.getByLabel("Source")).toBeVisible();
+  await expect(page.getByLabel("Amount (€)" )).toBeVisible();
+  await expect(page.getByRole("button", { name: "Add" })).toBeVisible();
+});


### PR DESCRIPTION
## Summary
- cover language switch to English in Playwright

## Testing
- `npm run test:e2e` *(fails: net::ERR_ABORTED)*

------
https://chatgpt.com/codex/tasks/task_e_6869277a46388333ad3d4ea6cfa039c9