### PR TITLE
Add Playwright scenarios and CI matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,10 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3
 
@@ -22,13 +25,24 @@ jobs:
           node-version: '20'
 
       - name: Install frontend deps
-        run: npm ci --prefix internal/ui
+        run: npm ci
+        working-directory: internal/ui
+
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps
+        working-directory: internal/ui
 
       - name: Lint frontend
-        run: npm run lint --prefix internal/ui
+        run: npm run lint
+        working-directory: internal/ui
 
       - name: Run frontend tests
-        run: npm test --prefix internal/ui
+        run: npm test
+        working-directory: internal/ui
+
+      - name: Run e2e tests
+        run: npm run test:e2e
+        working-directory: internal/ui
 
       - name: Go vet
         run: go vet ./cmd/... ./internal/... ./internal/pdf/...

--- a/internal/ui/e2e/export.spec.js
+++ b/internal/ui/e2e/export.spec.js
@@ -1,0 +1,27 @@
+import { test, expect } from "@playwright/test";
+import { fileURLToPath } from "url";
+import path from "path";
+
+test.beforeEach(async ({ page }) => {
+  const dir = path.dirname(fileURLToPath(import.meta.url));
+  await page.addInitScript({ path: path.join(dir, "mockDataService.js") });
+});
+
+test("export data", async ({ page }) => {
+  await page.goto("/");
+
+  await page.getByRole("textbox", { name: /Neues Projekt/i }).fill("Demo" );
+  await page.getByRole("button", { name: /Erstellen/i }).click();
+
+  await page.getByRole("tab", { name: /Einstellungen/i }).click();
+  await page.getByLabel(/Datenbank exportieren/i).fill("db.sqlite");
+  await page.getByRole("button", { name: /Datenbank exportieren/i }).click();
+  await page.getByLabel(/Projekt-CSV exportieren/i).fill("proj.csv");
+  await page.getByRole("button", { name: /Projekt-CSV exportieren/i }).click();
+
+  const exports = await page.evaluate(() => window.__exports);
+  expect(exports).toEqual([
+    { type: "db", dest: "db.sqlite" },
+    { type: "csv", pid: 1, dest: "proj.csv" },
+  ]);
+});

--- a/internal/ui/e2e/forms.spec.js
+++ b/internal/ui/e2e/forms.spec.js
@@ -1,0 +1,22 @@
+import { test, expect } from "@playwright/test";
+import { fileURLToPath } from "url";
+import path from "path";
+
+test.beforeEach(async ({ page }) => {
+  const dir = path.dirname(fileURLToPath(import.meta.url));
+  await page.addInitScript({ path: path.join(dir, "mockDataService.js") });
+  await page.addInitScript({ path: path.join(dir, "mockPDFGenerator.js") });
+});
+
+test("generate forms", async ({ page }) => {
+  await page.goto("/");
+
+  await page.getByRole("textbox", { name: /Neues Projekt/i }).fill("Demo");
+  await page.getByRole("button", { name: /Erstellen/i }).click();
+
+  await page.getByRole("tab", { name: /Formulare/i }).click();
+  await page.getByRole("button", { name: /Alle Formulare erstellen/i }).click();
+
+  const calls = await page.evaluate(() => window.__pdfCalls);
+  expect(calls.map((c) => c.name)).toContain("GenerateAllForms");
+});

--- a/internal/ui/e2e/mockDataService.js
+++ b/internal/ui/e2e/mockDataService.js
@@ -57,4 +57,15 @@
       }
     }
   };
+
+  const exports = [];
+  svc.ExportDatabase = async (dest) => {
+    exports.push({ type: "db", dest });
+  };
+  svc.ExportProjectCSV = async (pid, dest) => {
+    exports.push({ type: "csv", pid, dest });
+  };
+  svc.RestoreDatabase = async () => {};
+  svc.SetLogLevel = async () => {};
+  window.__exports = exports;
 })();

--- a/internal/ui/e2e/mockPDFGenerator.js
+++ b/internal/ui/e2e/mockPDFGenerator.js
@@ -1,0 +1,24 @@
+(() => {
+  window.go = window.go || {};
+  window.go.pdf = { Generator: {} };
+  const gen = window.go.pdf.Generator;
+  const calls = [];
+  function record(name) {
+    return async (...args) => {
+      calls.push({ name, args });
+      return `/tmp/${name}.pdf`;
+    };
+  }
+  [
+    'GenerateReport',
+    'GenerateKSt1',
+    'GenerateAnlageGem',
+    'GenerateAnlageGK',
+    'GenerateKSt1F',
+    'GenerateAnlageSport',
+    'GenerateAllForms',
+  ].forEach((m) => {
+    gen[m] = record(m);
+  });
+  window.__pdfCalls = calls;
+})();


### PR DESCRIPTION
## Summary
- mock PDF generator for e2e
- extend mock service with export helpers
- add form generation and data export tests
- run e2e tests in CI on all platforms

## Testing
- `npm test`
- `npm run test:e2e` *(fails: browser dependencies missing)*
- `go vet ./cmd/... ./internal/... ./internal/pdf/...`
- `go test ./cmd/... ./internal/... ./internal/pdf/...`

------
https://chatgpt.com/codex/tasks/task_e_6869418416c483338d7e7330f94da908