### PR TITLE
Add UI error dialogs

### DIFF
--- a/internal/ui/src/App.jsx
+++ b/internal/ui/src/App.jsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useCallback } from "react";
 import { ThemeProvider, createTheme } from "@mui/material/styles";
-import { CssBaseline, Container, FormControlLabel, Switch, AppBar, Toolbar, Typography, Tabs, Tab, Paper, Select, MenuItem } from "@mui/material";
+import { CssBaseline, Container, FormControlLabel, Switch, AppBar, Toolbar, Typography, Tabs, Tab, Paper, Select, MenuItem, Snackbar, Alert } from "@mui/material";
 import { useTranslation } from "react-i18next";
 import "./i18n";
 import { ListExpenses, ListIncomes, AddIncome, UpdateIncome, DeleteIncome, AddExpense, UpdateExpense, DeleteExpense, AddMember, ListMembers, DeleteMember } from "./wailsjs/go/service/DataService";
@@ -26,6 +26,10 @@ export default function App() {
   const [projectId, setProjectId] = useState(1);
   const { t, i18n } = useTranslation();
   const [language, setLanguage] = useState(i18n.language);
+  const [error, setError] = useState("");
+  const handleError = (err, key = 'errors.add') => {
+    setError(err.message || t(key));
+  };
 
   const theme = createTheme({
     palette: {
@@ -73,7 +77,7 @@ export default function App() {
       setError("");
       fetchIncomes();
     } catch (err) {
-      setError(err.message || t('add_error'));
+      handleError(err);
     }
   };
 
@@ -88,7 +92,7 @@ export default function App() {
       setError("");
       fetchExpenses();
     } catch (err) {
-      setError(err.message || t('add_error'));
+      handleError(err);
     }
   };
 
@@ -98,7 +102,7 @@ export default function App() {
       setError("");
       fetchMembers();
     } catch (err) {
-      setError(err.message || t('add_error'));
+      handleError(err);
     }
   };
 
@@ -210,6 +214,11 @@ export default function App() {
           </Paper>
         )}
       </Container>
+      <Snackbar open={!!error} autoHideDuration={6000} onClose={() => setError('')}>
+        <Alert severity="error" onClose={() => setError('')}>
+          {error}
+        </Alert>
+      </Snackbar>
     </ThemeProvider>
   );
 }

--- a/internal/ui/src/App.test.jsx
+++ b/internal/ui/src/App.test.jsx
@@ -91,7 +91,26 @@ test('shows error when adding income fails', async () => {
   fireEvent.change(screen.getByLabelText(/Betrag/i), { target: { value: '5' } });
   fireEvent.click(screen.getByRole('button', { name: /Hinzufügen/i }));
 
-  expect(await screen.findByText('fail')).toBeInTheDocument();
+  const alert = await screen.findByRole('alert');
+  expect(alert).toHaveTextContent('fail');
+});
+
+test('shows error when adding member fails', async () => {
+  ListExpenses.mockResolvedValueOnce([]);
+  ListIncomes.mockResolvedValueOnce([]);
+  ListMembers.mockResolvedValueOnce([]);
+  AddMember.mockRejectedValueOnce(new Error('oops'));
+  render(<App />);
+  await screen.findByRole('heading', { name: /Baristeuer/i });
+
+  fireEvent.click(screen.getByRole('tab', { name: /Mitglieder/i }));
+  fireEvent.change(screen.getByLabelText(/Name/i), { target: { value: 'A' } });
+  fireEvent.change(screen.getByLabelText(/E-Mail/i), { target: { value: 'a@example.com' } });
+  fireEvent.change(screen.getByLabelText(/Beitrittsdatum/i), { target: { value: '2024-01-10' } });
+  fireEvent.click(screen.getByRole('button', { name: /Hinzufügen/i }));
+
+  const alertMember = await screen.findByRole('alert');
+  expect(alertMember).toHaveTextContent('oops');
 });
 
 // Edit Income

--- a/internal/ui/src/components/ExpenseForm.jsx
+++ b/internal/ui/src/components/ExpenseForm.jsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { Box, TextField, Button, Typography } from "@mui/material";
+import { Box, TextField, Button, Snackbar, Alert } from "@mui/material";
 import { useTranslation } from "react-i18next";
 
 export default function ExpenseForm({ onSubmit, editItem }) {
@@ -12,11 +12,11 @@ export default function ExpenseForm({ onSubmit, editItem }) {
     e.preventDefault();
     const value = parseFloat(amount);
     if (!description || !amount) {
-      setError(t('expense.required'));
+      setError(t('errors.expense_required'));
       return;
     }
     if (Number.isNaN(value) || value <= 0) {
-      setError(t('expense.positive'));
+      setError(t('errors.expense_positive'));
       return;
     }
     await onSubmit(description, value, setError);
@@ -33,11 +33,11 @@ export default function ExpenseForm({ onSubmit, editItem }) {
       <Button type="submit" variant="contained">
         {t('expense.add')}
       </Button>
-      {error && (
-        <Typography color="error" sx={{ mt: 2 }}>
+      <Snackbar open={!!error} autoHideDuration={6000} onClose={() => setError('')}>
+        <Alert severity="error" onClose={() => setError('')}>
           {error}
-        </Typography>
-      )}
+        </Alert>
+      </Snackbar>
     </Box>
   );
 }

--- a/internal/ui/src/components/IncomeForm.jsx
+++ b/internal/ui/src/components/IncomeForm.jsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { Box, TextField, Button, Typography } from "@mui/material";
+import { Box, TextField, Button, Snackbar, Alert } from "@mui/material";
 import { useTranslation } from "react-i18next";
 
 export default function IncomeForm({ onSubmit, editItem }) {
@@ -12,11 +12,11 @@ export default function IncomeForm({ onSubmit, editItem }) {
     e.preventDefault();
     const value = parseFloat(amount);
     if (!source || !amount) {
-      setError(t('income.required'));
+      setError(t('errors.income_required'));
       return;
     }
     if (Number.isNaN(value) || value <= 0) {
-      setError(t('income.positive'));
+      setError(t('errors.income_positive'));
       return;
     }
     await onSubmit(source, value, setError);
@@ -33,11 +33,11 @@ export default function IncomeForm({ onSubmit, editItem }) {
       <Button type="submit" variant="contained">
         {t('income.add')}
       </Button>
-      {error && (
-        <Typography color="error" sx={{ mt: 2 }}>
+      <Snackbar open={!!error} autoHideDuration={6000} onClose={() => setError('')}>
+        <Alert severity="error" onClose={() => setError('')}>
           {error}
-        </Typography>
-      )}
+        </Alert>
+      </Snackbar>
     </Box>
   );
 }

--- a/internal/ui/src/components/MemberForm.jsx
+++ b/internal/ui/src/components/MemberForm.jsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { Box, TextField, Button, Typography } from "@mui/material";
+import { Box, TextField, Button, Snackbar, Alert } from "@mui/material";
 import { useTranslation } from "react-i18next";
 
 export default function MemberForm({ onSubmit }) {
@@ -14,15 +14,15 @@ export default function MemberForm({ onSubmit }) {
   const handleSubmit = async (e) => {
     e.preventDefault();
     if (!name || !email) {
-      setError(t('member.required'));
+      setError(t('errors.member_required'));
       return;
     }
     if (!emailPattern.test(email)) {
-      setError(t('member.invalid_email'));
+      setError(t('errors.member_invalid_email'));
       return;
     }
     if (!datePattern.test(joinDate)) {
-      setError(t('member.invalid_date'));
+      setError(t('errors.member_invalid_date'));
       return;
     }
     await onSubmit(name, email, joinDate, setError);
@@ -44,11 +44,11 @@ export default function MemberForm({ onSubmit }) {
       <Button type="submit" variant="contained">
         {t('member.add')}
       </Button>
-      {error && (
-        <Typography color="error" sx={{ mt: 2 }}>
+      <Snackbar open={!!error} autoHideDuration={6000} onClose={() => setError('')}>
+        <Alert severity="error" onClose={() => setError('')}>
           {error}
-        </Typography>
-      )}
+        </Alert>
+      </Snackbar>
     </Box>
   );
 }

--- a/internal/ui/src/locales/de.json
+++ b/internal/ui/src/locales/de.json
@@ -26,8 +26,6 @@
     "add": "Hinzufügen",
     "source": "Quelle",
     "amount": "Betrag (€)",
-    "required": "Quelle und Betrag erforderlich",
-    "positive": "Betrag muss eine positive Zahl sein",
     "table": {
       "source": "Quelle",
       "amount": "Betrag (€)",
@@ -40,8 +38,6 @@
     "add": "Hinzufügen",
     "description": "Beschreibung",
     "amount": "Betrag (€)",
-    "required": "Beschreibung und Betrag erforderlich",
-    "positive": "Betrag muss eine positive Zahl sein",
     "table": {
       "description": "Beschreibung",
       "amount": "Betrag (€)",
@@ -61,9 +57,6 @@
     "name": "Name",
     "email": "E-Mail",
     "joinDate": "Beitrittsdatum",
-    "required": "Name und E-Mail erforderlich",
-    "invalid_email": "Ungültige E-Mail-Adresse",
-    "invalid_date": "Ungültiges Datum",
     "table": {
       "name": "Name",
       "email": "E-Mail",
@@ -98,5 +91,14 @@
   "language_en": "Englisch",
   "edit": "Bearbeiten",
   "delete": "Löschen",
-  "add_error": "Fehler beim Hinzufügen"
+  "errors": {
+    "income_required": "Quelle und Betrag erforderlich",
+    "income_positive": "Betrag muss eine positive Zahl sein",
+    "expense_required": "Beschreibung und Betrag erforderlich",
+    "expense_positive": "Betrag muss eine positive Zahl sein",
+    "member_required": "Name und E-Mail erforderlich",
+    "member_invalid_email": "Ungültige E-Mail-Adresse",
+    "member_invalid_date": "Ungültiges Datum",
+    "add": "Fehler beim Hinzufügen"
+  }
 }

--- a/internal/ui/src/locales/en.json
+++ b/internal/ui/src/locales/en.json
@@ -26,8 +26,6 @@
     "add": "Add",
     "source": "Source",
     "amount": "Amount (€)",
-    "required": "Source and amount required",
-    "positive": "Amount must be a positive number",
     "table": {
       "source": "Source",
       "amount": "Amount (€)",
@@ -40,8 +38,6 @@
     "add": "Add",
     "description": "Description",
     "amount": "Amount (€)",
-    "required": "Description and amount required",
-    "positive": "Amount must be a positive number",
     "table": {
       "description": "Description",
       "amount": "Amount (€)",
@@ -61,9 +57,6 @@
     "name": "Name",
     "email": "Email",
     "joinDate": "Join Date",
-    "required": "Name and email required",
-    "invalid_email": "Invalid email address",
-    "invalid_date": "Invalid date",
     "table": {
       "name": "Name",
       "email": "Email",
@@ -98,5 +91,14 @@
   "language_en": "English",
   "edit": "Edit",
   "delete": "Delete",
-  "add_error": "Error adding item"
+  "errors": {
+    "income_required": "Source and amount required",
+    "income_positive": "Amount must be a positive number",
+    "expense_required": "Description and amount required",
+    "expense_positive": "Amount must be a positive number",
+    "member_required": "Name and email required",
+    "member_invalid_email": "Invalid email address",
+    "member_invalid_date": "Invalid date",
+    "add": "Error adding item"
+  }
 }


### PR DESCRIPTION
## Summary
- centralize error messages under new `errors` translation section
- show validation errors in Snackbars in form components
- handle API errors globally in `App.jsx`
- extend tests with Snackbar scenarios

## Testing
- `npx vitest --run` *(fails: Cannot find package 'vite')*

------
https://chatgpt.com/codex/tasks/task_e_6869418259348333b40c451d26a47a8b