### PR TITLE
Add tax year config and UI

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -52,7 +52,7 @@ func main() {
 	}
 
 	logger, logCloser := service.NewLogger(cfg.LogFile, cfg.LogLevel)
-	generator := pdf.NewGenerator(cfg.PDFDir, store)
+	generator := pdf.NewGenerator(cfg.PDFDir, store, &cfg)
 	datasvc := service.NewDataServiceFromStore(store, logger, logCloser)
 	defer datasvc.Close()
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -8,10 +8,14 @@ import (
 
 // Config holds application configuration values.
 type Config struct {
-	DBPath   string `json:"dbPath"`
-	PDFDir   string `json:"pdfDir"`
-	LogFile  string `json:"logFile"`
-	LogLevel string `json:"logLevel"`
+	DBPath        string `json:"dbPath"`
+	PDFDir        string `json:"pdfDir"`
+	LogFile       string `json:"logFile"`
+	LogLevel      string `json:"logLevel"`
+	TaxYear       int    `json:"taxYear"`
+	FormName      string `json:"formName"`
+	FormTaxNumber string `json:"formTaxNumber"`
+	FormAddress   string `json:"formAddress"`
 }
 
 // Load reads configuration from the given file path. If the file does not exist,

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -14,7 +14,11 @@ func TestLoadFromFile(t *testing.T) {
         "dbPath": "db.sqlite",
         "pdfDir": "./pdfs",
         "logFile": "app.log",
-        "logLevel": "debug"
+        "logLevel": "debug",
+        "taxYear": 2026,
+        "formName": "Club",
+        "formTaxNumber": "11/111/11111",
+        "formAddress": "Street 1"
     }`
 	if err := os.WriteFile(path, []byte(data), 0o644); err != nil {
 		t.Fatal(err)
@@ -24,7 +28,8 @@ func TestLoadFromFile(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Load returned error: %v", err)
 	}
-	if cfg.DBPath != "db.sqlite" || cfg.PDFDir != "./pdfs" || cfg.LogFile != "app.log" || cfg.LogLevel != "debug" {
+	if cfg.DBPath != "db.sqlite" || cfg.PDFDir != "./pdfs" || cfg.LogFile != "app.log" || cfg.LogLevel != "debug" ||
+		cfg.TaxYear != 2026 || cfg.FormName != "Club" || cfg.FormTaxNumber != "11/111/11111" || cfg.FormAddress != "Street 1" {
 		t.Fatalf("unexpected config: %+v", cfg)
 	}
 }
@@ -45,7 +50,7 @@ func TestLoadMissingFile(t *testing.T) {
 func TestSaveAndVerify(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "out.json")
-	expected := Config{DBPath: "db", PDFDir: "pdf", LogFile: "log", LogLevel: "info"}
+	expected := Config{DBPath: "db", PDFDir: "pdf", LogFile: "log", LogLevel: "info", TaxYear: 2025, FormName: "Org", FormTaxNumber: "12/222/22222", FormAddress: "Main"}
 
 	if err := Save(path, expected); err != nil {
 		t.Fatalf("Save returned error: %v", err)

--- a/internal/pdf/pdf_test.go
+++ b/internal/pdf/pdf_test.go
@@ -7,13 +7,14 @@ import (
 	"strings"
 	"testing"
 
+	"baristeuer/internal/config"
 	"baristeuer/internal/data"
 )
 
 func TestNewGeneratorEnvVar(t *testing.T) {
 	dir := t.TempDir()
 	t.Setenv("BARISTEUER_PDFDIR", dir)
-	g := NewGenerator("", nil)
+	g := NewGenerator("", nil, &config.Config{})
 	if g.BasePath != dir {
 		t.Fatalf("expected %s, got %s", dir, g.BasePath)
 	}
@@ -40,7 +41,8 @@ func TestGenerateReport(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	g := NewGenerator(dir, store)
+	cfg := config.Config{TaxYear: 2026}
+	g := NewGenerator(dir, store, &cfg)
 	path, err := g.GenerateReport(proj.ID)
 	if err != nil {
 		t.Fatalf("GenerateReport failed: %v", err)
@@ -49,7 +51,7 @@ func TestGenerateReport(t *testing.T) {
 	if err != nil {
 		t.Fatalf("read %s failed: %v", path, err)
 	}
-	expect := []string{"100.00 EUR", "20.00 EUR", "80.00 EUR"}
+	expect := []string{"100.00 EUR", "20.00 EUR", "80.00 EUR", "2026"}
 	for _, e := range expect {
 		if !strings.Contains(string(data), e) {
 			t.Fatalf("missing %s in pdf", e)
@@ -84,21 +86,21 @@ func TestFormGeneration(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	g := NewGenerator(dir, store)
-	info := FormInfo{Name: "Testverein", TaxNumber: "11/111/11111", Address: "Hauptstr. 1", FiscalYear: "2025"}
+	cfg := config.Config{TaxYear: 2026, FormName: "Testverein", FormTaxNumber: "11/111/11111", FormAddress: "Hauptstr. 1"}
+	g := NewGenerator(dir, store, &cfg)
 	files := []struct {
 		name     string
-		fn       func(int64, FormInfo) (string, error)
+		fn       func(int64) (string, error)
 		expected []string
 	}{
-		{"kst1", g.GenerateKSt1, []string{"Einnahmen gesamt", "100.00", "Ausgaben gesamt"}},
+		{"kst1", g.GenerateKSt1, []string{"Einnahmen gesamt", "100.00", "Ausgaben gesamt", "2026"}},
 		{"gem", g.GenerateAnlageGem, []string{"Mitglieder:", "1", "Einnahmen:", "100.00"}},
 		{"gk", g.GenerateAnlageGK, []string{"Gesamte Einnahmen", "100.00"}},
 		{"kst1f", g.GenerateKSt1F, []string{"Gesamteinnahmen", "100.00"}},
 		{"sport", g.GenerateAnlageSport, []string{"Mitgliederzahl", "1", "Einnahmen aus Sportbetrieb"}},
 	}
 	for _, f := range files {
-		path, err := f.fn(proj.ID, info)
+		path, err := f.fn(proj.ID)
 		if err != nil {
 			t.Fatalf("%s failed: %v", f.name, err)
 		}
@@ -114,7 +116,7 @@ func TestFormGeneration(t *testing.T) {
 	}
 
 	// test GenerateAllForms
-	paths, err := g.GenerateAllForms(proj.ID, info)
+	paths, err := g.GenerateAllForms(proj.ID)
 	if err != nil {
 		t.Fatalf("GenerateAllForms failed: %v", err)
 	}
@@ -160,7 +162,7 @@ func TestGenerateReportCombinations(t *testing.T) {
 				}
 			}
 
-			g := NewGenerator(dir, store)
+			g := NewGenerator(dir, store, &config.Config{})
 			path, err := g.GenerateReport(proj.ID)
 			if err != nil {
 				t.Fatalf("GenerateReport failed: %v", err)

--- a/internal/ui/src/components/SettingsPanel.jsx
+++ b/internal/ui/src/components/SettingsPanel.jsx
@@ -14,6 +14,7 @@ import {
   SetLogLevel,
   ExportProjectCSV,
 } from "../wailsjs/go/service/DataService";
+import { SetTaxYear } from "../wailsjs/go/pdf/Generator";
 
 export default function SettingsPanel({ projectId }) {
   const { t } = useTranslation();
@@ -21,6 +22,7 @@ export default function SettingsPanel({ projectId }) {
   const [restorePath, setRestorePath] = useState("");
   const [csvPath, setCsvPath] = useState("");
   const [level, setLevel] = useState("info");
+  const [taxYear, setTaxYear] = useState(2025);
   const [msg, setMsg] = useState("");
 
   const doExport = async () => {
@@ -52,6 +54,11 @@ export default function SettingsPanel({ projectId }) {
 
   const changeLevel = () => {
     SetLogLevel(level);
+    setMsg(t("settings.applied"));
+  };
+
+  const applyYear = () => {
+    SetTaxYear(parseInt(taxYear));
     setMsg(t("settings.applied"));
   };
 
@@ -105,6 +112,18 @@ export default function SettingsPanel({ projectId }) {
           <MenuItem value="error">error</MenuItem>
         </Select>
         <Button variant="outlined" onClick={changeLevel}>
+          {t("settings.apply")}
+        </Button>
+      </Box>
+      <Box sx={{ display: "flex", gap: 2, alignItems: "center" }}>
+        <TextField
+          label={t("settings.tax_year") || "Tax Year"}
+          type="number"
+          value={taxYear}
+          onChange={(e) => setTaxYear(e.target.value)}
+          size="small"
+        />
+        <Button variant="outlined" onClick={applyYear}>
           {t("settings.apply")}
         </Button>
       </Box>

--- a/internal/ui/src/locales/de.json
+++ b/internal/ui/src/locales/de.json
@@ -19,7 +19,8 @@
     "apply": "Anwenden",
     "exported": "Datenbank exportiert",
     "restored": "Datenbank wiederhergestellt",
-    "csv_exported": "CSV exportiert"
+    "csv_exported": "CSV exportiert",
+    "tax_year": "Steuerjahr"
   },
   "income": {
     "new": "Neue Einnahme",

--- a/internal/ui/src/locales/en.json
+++ b/internal/ui/src/locales/en.json
@@ -19,7 +19,8 @@
     "apply": "Apply",
     "exported": "Database exported",
     "restored": "Database restored",
-    "csv_exported": "CSV exported"
+    "csv_exported": "CSV exported",
+    "tax_year": "Tax Year"
   },
   "income": {
     "new": "New Income",

--- a/internal/ui/src/wailsjs/go/pdf/Generator.js
+++ b/internal/ui/src/wailsjs/go/pdf/Generator.js
@@ -25,3 +25,7 @@ export function GenerateAnlageSport(projectID) {
 export function GenerateAllForms(projectID) {
   return window.go.pdf.Generator.GenerateAllForms(projectID);
 }
+
+export function SetTaxYear(year) {
+  return window.go.pdf.Generator.SetTaxYear(year);
+}


### PR DESCRIPTION
## Summary
- add tax year and form fields to Config
- read tax year and form details from config in PDF generator
- allow changing tax year from the settings panel
- update tests for config, PDF generation and tax logic

## Testing
- `go vet ./cmd/... ./internal/... ./internal/pdf/...`
- `go test ./cmd/... ./internal/... ./internal/pdf/...`
- `npm ci --prefix internal/ui`
- `npm test --prefix internal/ui`


------
https://chatgpt.com/codex/tasks/task_e_6869418319a08333be1d0cd0c025a374