### PR TITLE
Add example config and default creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,8 @@ To restore a previously exported database before launching the UI, use `-restore
 
 You can export all incomes and expenses of a project to CSV via the service method `ExportProjectCSV` or by using the UI settings panel.
 
+For the first start, copy the provided `config.example.json` to `config.json` and adjust the paths if needed.
+
 A minimal `config.json` might look like:
 
 ```json

--- a/config.example.json
+++ b/config.example.json
@@ -1,0 +1,6 @@
+{
+  "dbPath": "baristeuer.db",
+  "pdfDir": "./internal/data/reports",
+  "logFile": "baristeuer.log",
+  "logLevel": "info"
+}

--- a/docs/DOCUMENTATION.md
+++ b/docs/DOCUMENTATION.md
@@ -68,7 +68,9 @@ npm test --prefix internal/ui
 ## Configuration
 
 Runtime options can be provided via a JSON configuration file. By default the
-application looks for `config.json` in the working directory. Example:
+application looks for `config.json` in the working directory. Copy
+`config.example.json` to `config.json` when running the application for the first
+time. Example:
 
 ```json
 {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"path/filepath"
 )
 
 // Config holds application configuration values.
@@ -14,6 +15,14 @@ type Config struct {
 	LogLevel string `json:"logLevel"`
 }
 
+// DefaultConfig provides sensible defaults for a new configuration file.
+var DefaultConfig = Config{
+	DBPath:   "baristeuer.db",
+	PDFDir:   filepath.Join(".", "internal", "data", "reports"),
+	LogFile:  "baristeuer.log",
+	LogLevel: "info",
+}
+
 // Load reads configuration from the given file path. If the file does not exist,
 // default values are returned and no error is raised.
 func Load(path string) (Config, error) {
@@ -21,6 +30,10 @@ func Load(path string) (Config, error) {
 	f, err := os.Open(path)
 	if err != nil {
 		if os.IsNotExist(err) {
+			cfg = DefaultConfig
+			if err := Save(path, cfg); err != nil {
+				return cfg, nil
+			}
 			return cfg, nil
 		}
 		return cfg, fmt.Errorf("open config: %w", err)

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -37,8 +37,11 @@ func TestLoadMissingFile(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Load returned error: %v", err)
 	}
-	if cfg != (Config{}) {
-		t.Fatalf("expected zero config, got %+v", cfg)
+	if cfg != DefaultConfig {
+		t.Fatalf("expected default config, got %+v", cfg)
+	}
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("config file not created: %v", err)
 	}
 }
 


### PR DESCRIPTION
## Summary
- add `config.example.json` with default settings
- explain copying the file in README and DOCUMENTATION
- generate a default config if no config file exists
- adjust tests for new behaviour

## Testing
- `go work sync`
- `go test ./cmd/... ./internal/... ./internal/pdf/...`
- `npm ci --prefix internal/ui`
- `npm test --prefix internal/ui`


------
https://chatgpt.com/codex/tasks/task_e_68694180a4b48333ae83a63264205105