### PR TITLE
Implement multi-user authentication

### DIFF
--- a/internal/data/models.go
+++ b/internal/data/models.go
@@ -2,8 +2,9 @@ package data
 
 // Project represents a club project with a name.
 type Project struct {
-	ID   int64  `db:"id"`
-	Name string `db:"name"`
+	ID     int64  `db:"id"`
+	UserID int64  `db:"user_id"`
+	Name   string `db:"name"`
 }
 
 // Income represents income for a project.
@@ -28,4 +29,11 @@ type Member struct {
 	Name     string `db:"name"`
 	Email    string `db:"email"`
 	JoinDate string `db:"join_date"`
+}
+
+// User represents an application user.
+type User struct {
+	ID           int64  `db:"id"`
+	Username     string `db:"username"`
+	PasswordHash string `db:"password_hash"`
 }

--- a/internal/data/store_test.go
+++ b/internal/data/store_test.go
@@ -231,3 +231,24 @@ func TestMemberQueryByName(t *testing.T) {
 		t.Fatalf("queried member mismatch: %+v vs %+v", got, m)
 	}
 }
+
+func TestUserCreateAndQuery(t *testing.T) {
+	s, err := NewStore(":memory:")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer s.Close()
+
+	ctx := context.Background()
+	u := &User{Username: "foo", PasswordHash: "bar"}
+	if err := s.CreateUser(ctx, u); err != nil {
+		t.Fatal(err)
+	}
+	got, err := s.GetUserByUsername(ctx, u.Username)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.ID != u.ID || got.Username != u.Username {
+		t.Fatalf("user mismatch: %+v vs %+v", got, u)
+	}
+}

--- a/internal/go.mod
+++ b/internal/go.mod
@@ -6,3 +6,5 @@ require (
 	github.com/mattn/go-sqlite3 v1.14.28
 	gopkg.in/natefinch/lumberjack.v2 v2.2.1
 )
+
+require golang.org/x/crypto v0.33.0 // indirect

--- a/internal/go.sum
+++ b/internal/go.sum
@@ -1,4 +1,6 @@
 github.com/mattn/go-sqlite3 v1.14.28 h1:ThEiQrnbtumT+QMknw63Befp/ce/nUPgBPMlRFEum7A=
 github.com/mattn/go-sqlite3 v1.14.28/go.mod h1:Uh1q+B4BYcTPb+yiD3kU8Ct7aC0hY9fxUwlHK0RXw+Y=
+golang.org/x/crypto v0.33.0 h1:IOBPskki6Lysi0lo9qQvbxiQ+FvsCC/YWOecCHAixus=
+golang.org/x/crypto v0.33.0/go.mod h1:bVdXmD7IV/4GdElGPozy6U7lWdRXA4qyRVGJV57uQ5M=
 gopkg.in/natefinch/lumberjack.v2 v2.2.1 h1:bBRl1b0OH9s/DuPhuXpNl+VtCaJXFZ5/uEFST95x9zc=
 gopkg.in/natefinch/lumberjack.v2 v2.2.1/go.mod h1:YD8tP3GAjkrDg1eZH7EGmyESg/lsYskCTPBJVb9jqSc=

--- a/internal/ui/src/App.jsx
+++ b/internal/ui/src/App.jsx
@@ -1,9 +1,35 @@
 import { useState, useEffect, useCallback } from "react";
 import { ThemeProvider, createTheme } from "@mui/material/styles";
-import { CssBaseline, Container, FormControlLabel, Switch, AppBar, Toolbar, Typography, Tabs, Tab, Paper, Select, MenuItem } from "@mui/material";
+import {
+  CssBaseline,
+  Container,
+  FormControlLabel,
+  Switch,
+  AppBar,
+  Toolbar,
+  Typography,
+  Tabs,
+  Tab,
+  Paper,
+  Select,
+  MenuItem,
+} from "@mui/material";
 import { useTranslation } from "react-i18next";
 import "./i18n";
-import { ListExpenses, ListIncomes, AddIncome, UpdateIncome, DeleteIncome, AddExpense, UpdateExpense, DeleteExpense, AddMember, ListMembers, DeleteMember } from "./wailsjs/go/service/DataService";
+import {
+  ListExpenses,
+  ListIncomes,
+  AddIncome,
+  UpdateIncome,
+  DeleteIncome,
+  AddExpense,
+  UpdateExpense,
+  DeleteExpense,
+  AddMember,
+  ListMembers,
+  DeleteMember,
+  Login,
+} from "./wailsjs/go/service/DataService";
 import ProjectPanel from "./components/ProjectPanel";
 import IncomeForm from "./components/IncomeForm";
 import IncomeTable from "./components/IncomeTable";
@@ -14,6 +40,7 @@ import MemberTable from "./components/MemberTable";
 import TaxPanel from "./components/TaxPanel";
 import FormsPanel from "./components/FormsPanel";
 import SettingsPanel from "./components/SettingsPanel";
+import LoginPanel from "./components/LoginPanel";
 
 export default function App() {
   const [incomes, setIncomes] = useState([]);
@@ -24,6 +51,7 @@ export default function App() {
   const [darkMode, setDarkMode] = useState(false);
   const [tab, setTab] = useState(2);
   const [projectId, setProjectId] = useState(1);
+  const [loggedIn, setLoggedIn] = useState(false);
   const { t, i18n } = useTranslation();
   const [language, setLanguage] = useState(i18n.language);
 
@@ -73,7 +101,7 @@ export default function App() {
       setError("");
       fetchIncomes();
     } catch (err) {
-      setError(err.message || t('add_error'));
+      setError(err.message || t("add_error"));
     }
   };
 
@@ -88,7 +116,7 @@ export default function App() {
       setError("");
       fetchExpenses();
     } catch (err) {
-      setError(err.message || t('add_error'));
+      setError(err.message || t("add_error"));
     }
   };
 
@@ -98,9 +126,20 @@ export default function App() {
       setError("");
       fetchMembers();
     } catch (err) {
-      setError(err.message || t('add_error'));
+      setError(err.message || t("add_error"));
     }
   };
+
+  if (!loggedIn) {
+    return (
+      <ThemeProvider theme={theme}>
+        <CssBaseline />
+        <Container maxWidth="sm">
+          <LoginPanel onLoggedIn={() => setLoggedIn(true)} />
+        </Container>
+      </ThemeProvider>
+    );
+  }
 
   return (
     <ThemeProvider theme={theme}>
@@ -114,36 +153,51 @@ export default function App() {
             value={language}
             onChange={handleLanguageChange}
             size="small"
-            sx={{ mr: 2, color: 'inherit' }}
+            sx={{ mr: 2, color: "inherit" }}
             variant="standard"
           >
             <MenuItem value="de">DE</MenuItem>
             <MenuItem value="en">EN</MenuItem>
           </Select>
           <FormControlLabel
-            control={<Switch checked={darkMode} onChange={() => setDarkMode(!darkMode)} color="default" />}
-            label={darkMode ? t('theme.dark') : t('theme.light')}
+            control={
+              <Switch
+                checked={darkMode}
+                onChange={() => setDarkMode(!darkMode)}
+                color="default"
+              />
+            }
+            label={darkMode ? t("theme.dark") : t("theme.light")}
           />
         </Toolbar>
-        <Tabs value={tab} onChange={(_, v) => setTab(v)} textColor="inherit" indicatorColor="secondary" centered>
-          <Tab label={t('tab.projects')} />
-          <Tab label={t('tab.members')} />
-          <Tab label={t('tab.incomes')} />
-          <Tab label={t('tab.expenses')} />
-          <Tab label={t('tab.forms')} />
-          <Tab label={t('tab.taxes')} />
-          <Tab label={t('tab.settings')} />
+        <Tabs
+          value={tab}
+          onChange={(_, v) => setTab(v)}
+          textColor="inherit"
+          indicatorColor="secondary"
+          centered
+        >
+          <Tab label={t("tab.projects")} />
+          <Tab label={t("tab.members")} />
+          <Tab label={t("tab.incomes")} />
+          <Tab label={t("tab.expenses")} />
+          <Tab label={t("tab.forms")} />
+          <Tab label={t("tab.taxes")} />
+          <Tab label={t("tab.settings")} />
         </Tabs>
       </AppBar>
       <Container maxWidth="md" sx={{ py: 4 }}>
         {tab === 0 && (
-          <ProjectPanel activeId={projectId} onSelect={(id) => setProjectId(id)} />
+          <ProjectPanel
+            activeId={projectId}
+            onSelect={(id) => setProjectId(id)}
+          />
         )}
         {tab === 1 && (
           <>
             <Paper sx={{ p: 3, mb: 4 }}>
               <Typography variant="h6" component="h2" gutterBottom>
-                {t('member.new')}
+                {t("member.new")}
               </Typography>
               <MemberForm onSubmit={submitMember} />
             </Paper>
@@ -162,7 +216,7 @@ export default function App() {
           <>
             <Paper sx={{ p: 3, mb: 4 }}>
               <Typography variant="h6" component="h2" gutterBottom>
-                {t('income.new')}
+                {t("income.new")}
               </Typography>
               <IncomeForm onSubmit={submitIncome} editItem={editIncome} />
             </Paper>
@@ -182,7 +236,7 @@ export default function App() {
           <>
             <Paper sx={{ p: 3, mb: 4 }}>
               <Typography variant="h6" component="h2" gutterBottom>
-                {t('expense.new')}
+                {t("expense.new")}
               </Typography>
               <ExpenseForm onSubmit={submitExpense} editItem={editExpense} />
             </Paper>

--- a/internal/ui/src/App.test.jsx
+++ b/internal/ui/src/App.test.jsx
@@ -1,29 +1,34 @@
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
-import '@testing-library/jest-dom';
-import { vi, beforeEach } from 'vitest';
-import App from './App';
-import './i18n';
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import { vi, beforeEach } from "vitest";
+import App from "./App";
+import "./i18n";
 
 // mock the DataService module used by App
-vi.mock('./wailsjs/go/service/DataService', () => ({
-  CreateProject: vi.fn(),
-  ListProjects: vi.fn(),
-  GetProject: vi.fn(),
-  UpdateProject: vi.fn(),
-  DeleteProject: vi.fn(),
-  AddExpense: vi.fn(),
-  UpdateExpense: vi.fn(),
-  DeleteExpense: vi.fn(),
-  ListExpenses: vi.fn(),
-  AddIncome: vi.fn(),
-  UpdateIncome: vi.fn(),
-  DeleteIncome: vi.fn(),
-  ListIncomes: vi.fn(),
-  AddMember: vi.fn(),
-  ListMembers: vi.fn(),
-  DeleteMember: vi.fn(),
-  CalculateProjectTaxes: vi.fn(),
-}), { virtual: true });
+vi.mock(
+  "./wailsjs/go/service/DataService",
+  () => ({
+    CreateProject: vi.fn(),
+    ListProjects: vi.fn(),
+    GetProject: vi.fn(),
+    UpdateProject: vi.fn(),
+    DeleteProject: vi.fn(),
+    AddExpense: vi.fn(),
+    UpdateExpense: vi.fn(),
+    DeleteExpense: vi.fn(),
+    ListExpenses: vi.fn(),
+    AddIncome: vi.fn(),
+    UpdateIncome: vi.fn(),
+    DeleteIncome: vi.fn(),
+    ListIncomes: vi.fn(),
+    AddMember: vi.fn(),
+    ListMembers: vi.fn(),
+    DeleteMember: vi.fn(),
+    CalculateProjectTaxes: vi.fn(),
+    Login: vi.fn(),
+  }),
+  { virtual: true },
+);
 
 // import the mocked functions for easier access
 import {
@@ -44,204 +49,278 @@ import {
   ListMembers,
   DeleteMember,
   CalculateProjectTaxes,
-} from './wailsjs/go/service/DataService';
+  Login,
+} from "./wailsjs/go/service/DataService";
 
 beforeEach(() => {
   vi.clearAllMocks();
 });
 
-test('renders app heading', async () => {
+async function login() {
+  render(<App />);
+  fireEvent.change(screen.getByLabelText(/Benutzer/i), {
+    target: { value: "u" },
+  });
+  fireEvent.change(screen.getByLabelText(/Passwort/i), {
+    target: { value: "p" },
+  });
+  fireEvent.click(screen.getByRole("button", { name: /Anmelden/i }));
+  await waitFor(() => expect(Login).toHaveBeenCalled());
+}
+
+test("renders app heading", async () => {
   ListExpenses.mockResolvedValueOnce([]);
   ListIncomes.mockResolvedValueOnce([]);
   ListMembers.mockResolvedValueOnce([]);
-  render(<App />);
-  expect(await screen.findByRole('heading', { name: /Baristeuer/i })).toBeInTheDocument();
+  await login();
+  expect(
+    await screen.findByRole("heading", { name: /Baristeuer/i }),
+  ).toBeInTheDocument();
 });
 
 // Add Income
 
-test('adds a new income', async () => {
+test("adds a new income", async () => {
   ListExpenses.mockResolvedValueOnce([]);
-  ListIncomes.mockResolvedValueOnce([]).mockResolvedValueOnce([{ id: 1, source: 'Donation', amount: 50 }]);
+  ListIncomes.mockResolvedValueOnce([]).mockResolvedValueOnce([
+    { id: 1, source: "Donation", amount: 50 },
+  ]);
   ListMembers.mockResolvedValueOnce([]);
   AddIncome.mockResolvedValueOnce();
-  render(<App />);
-  await screen.findByRole('heading', { name: /Baristeuer/i });
+  await login();
 
-  fireEvent.change(screen.getByLabelText(/Quelle/i), { target: { value: 'Donation' } });
-  fireEvent.change(screen.getByLabelText(/Betrag/i), { target: { value: '50' } });
-  fireEvent.click(screen.getByRole('button', { name: /Hinzufügen/i }));
+  fireEvent.change(screen.getByLabelText(/Quelle/i), {
+    target: { value: "Donation" },
+  });
+  fireEvent.change(screen.getByLabelText(/Betrag/i), {
+    target: { value: "50" },
+  });
+  fireEvent.click(screen.getByRole("button", { name: /Hinzufügen/i }));
 
   await waitFor(() => expect(AddIncome).toHaveBeenCalled());
-  expect(await screen.findByText('Donation')).toBeInTheDocument();
-  expect(screen.getByText('50.00')).toBeInTheDocument();
+  expect(await screen.findByText("Donation")).toBeInTheDocument();
+  expect(screen.getByText("50.00")).toBeInTheDocument();
 });
 
 // Failed add income
 
-test('shows error when adding income fails', async () => {
+test("shows error when adding income fails", async () => {
   ListExpenses.mockResolvedValueOnce([]);
   ListIncomes.mockResolvedValueOnce([]);
   ListMembers.mockResolvedValueOnce([]);
-  AddIncome.mockRejectedValueOnce(new Error('fail'));
-  render(<App />);
-  await screen.findByRole('heading', { name: /Baristeuer/i });
+  AddIncome.mockRejectedValueOnce(new Error("fail"));
+  await login();
 
-  fireEvent.change(screen.getByLabelText(/Quelle/i), { target: { value: 'Foo' } });
-  fireEvent.change(screen.getByLabelText(/Betrag/i), { target: { value: '5' } });
-  fireEvent.click(screen.getByRole('button', { name: /Hinzufügen/i }));
+  fireEvent.change(screen.getByLabelText(/Quelle/i), {
+    target: { value: "Foo" },
+  });
+  fireEvent.change(screen.getByLabelText(/Betrag/i), {
+    target: { value: "5" },
+  });
+  fireEvent.click(screen.getByRole("button", { name: /Hinzufügen/i }));
 
-  expect(await screen.findByText('fail')).toBeInTheDocument();
+  expect(await screen.findByText("fail")).toBeInTheDocument();
 });
 
 // Edit Income
 
-test('edits an income', async () => {
+test("edits an income", async () => {
   ListExpenses.mockResolvedValueOnce([]);
-  ListIncomes.mockResolvedValueOnce([{ id: 1, source: 'Old', amount: 10 }]).mockResolvedValueOnce([{ id: 1, source: 'New', amount: 20 }]);
+  ListIncomes.mockResolvedValueOnce([
+    { id: 1, source: "Old", amount: 10 },
+  ]).mockResolvedValueOnce([{ id: 1, source: "New", amount: 20 }]);
   ListMembers.mockResolvedValueOnce([]);
   UpdateIncome.mockResolvedValueOnce();
-  render(<App />);
-  await screen.findByText('Old');
+  await login();
+  await screen.findByText("Old");
 
-  fireEvent.click(screen.getByRole('button', { name: /Bearbeiten/i }));
-  fireEvent.change(screen.getByLabelText(/Quelle/i), { target: { value: 'New' } });
-  fireEvent.change(screen.getByLabelText(/Betrag/i), { target: { value: '20' } });
-  fireEvent.click(screen.getByRole('button', { name: /Hinzufügen/i }));
+  fireEvent.click(screen.getByRole("button", { name: /Bearbeiten/i }));
+  fireEvent.change(screen.getByLabelText(/Quelle/i), {
+    target: { value: "New" },
+  });
+  fireEvent.change(screen.getByLabelText(/Betrag/i), {
+    target: { value: "20" },
+  });
+  fireEvent.click(screen.getByRole("button", { name: /Hinzufügen/i }));
 
-  await waitFor(() => expect(UpdateIncome).toHaveBeenCalledWith(1, 1, 'New', 20));
-  expect(await screen.findByText('New')).toBeInTheDocument();
+  await waitFor(() =>
+    expect(UpdateIncome).toHaveBeenCalledWith(1, 1, "New", 20),
+  );
+  expect(await screen.findByText("New")).toBeInTheDocument();
 });
 
 // Delete Income
 
-test('deletes an income', async () => {
+test("deletes an income", async () => {
   ListExpenses.mockResolvedValueOnce([]);
-  ListIncomes.mockResolvedValueOnce([{ id: 1, source: 'Del', amount: 30 }]).mockResolvedValueOnce([]);
+  ListIncomes.mockResolvedValueOnce([
+    { id: 1, source: "Del", amount: 30 },
+  ]).mockResolvedValueOnce([]);
   ListMembers.mockResolvedValueOnce([]);
   DeleteIncome.mockResolvedValueOnce();
-  render(<App />);
-  await screen.findByText('Del');
+  await login();
+  await screen.findByText("Del");
 
-  fireEvent.click(screen.getByRole('button', { name: /Löschen/i }));
+  fireEvent.click(screen.getByRole("button", { name: /Löschen/i }));
 
   await waitFor(() => expect(DeleteIncome).toHaveBeenCalledWith(1));
-  await waitFor(() => expect(screen.queryByText('Del')).not.toBeInTheDocument());
+  await waitFor(() =>
+    expect(screen.queryByText("Del")).not.toBeInTheDocument(),
+  );
 });
 
 // Add Expense
 
-test('adds a new expense', async () => {
+test("adds a new expense", async () => {
   ListIncomes.mockResolvedValueOnce([]);
-  ListExpenses.mockResolvedValueOnce([]).mockResolvedValueOnce([{ id: 1, description: 'Rent', amount: 15 }]);
+  ListExpenses.mockResolvedValueOnce([]).mockResolvedValueOnce([
+    { id: 1, description: "Rent", amount: 15 },
+  ]);
   ListMembers.mockResolvedValueOnce([]);
   AddExpense.mockResolvedValueOnce();
-  render(<App />);
-  await screen.findByRole('heading', { name: /Baristeuer/i });
+  await login();
 
-  fireEvent.click(screen.getByRole('tab', { name: /Ausgaben/i }));
-  fireEvent.change(screen.getByLabelText(/Beschreibung/i), { target: { value: 'Rent' } });
-  fireEvent.change(screen.getByLabelText(/Betrag/i), { target: { value: '15' } });
-  fireEvent.click(screen.getByRole('button', { name: /Hinzufügen/i }));
+  fireEvent.click(screen.getByRole("tab", { name: /Ausgaben/i }));
+  fireEvent.change(screen.getByLabelText(/Beschreibung/i), {
+    target: { value: "Rent" },
+  });
+  fireEvent.change(screen.getByLabelText(/Betrag/i), {
+    target: { value: "15" },
+  });
+  fireEvent.click(screen.getByRole("button", { name: /Hinzufügen/i }));
 
   await waitFor(() => expect(AddExpense).toHaveBeenCalled());
-  expect(await screen.findByText('Rent')).toBeInTheDocument();
-  expect(screen.getByText('15.00')).toBeInTheDocument();
+  expect(await screen.findByText("Rent")).toBeInTheDocument();
+  expect(screen.getByText("15.00")).toBeInTheDocument();
 });
 
 // Edit Expense
 
-test('edits an expense', async () => {
+test("edits an expense", async () => {
   ListIncomes.mockResolvedValueOnce([]);
-  ListExpenses.mockResolvedValueOnce([{ id: 1, description: 'Coffee', amount: 3 }]).mockResolvedValueOnce([{ id: 1, description: 'Tea', amount: 4 }]);
+  ListExpenses.mockResolvedValueOnce([
+    { id: 1, description: "Coffee", amount: 3 },
+  ]).mockResolvedValueOnce([{ id: 1, description: "Tea", amount: 4 }]);
   ListMembers.mockResolvedValueOnce([]);
   UpdateExpense.mockResolvedValueOnce();
-  render(<App />);
-  await screen.findByRole('heading', { name: /Baristeuer/i });
-  fireEvent.click(screen.getByRole('tab', { name: /Ausgaben/i }));
-  await screen.findByText('Coffee');
+  await login();
+  fireEvent.click(screen.getByRole("tab", { name: /Ausgaben/i }));
+  await screen.findByText("Coffee");
 
-  fireEvent.click(screen.getByRole('button', { name: /Bearbeiten/i }));
-  fireEvent.change(screen.getByLabelText(/Beschreibung/i), { target: { value: 'Tea' } });
-  fireEvent.change(screen.getByLabelText(/Betrag/i), { target: { value: '4' } });
-  fireEvent.click(screen.getByRole('button', { name: /Hinzufügen/i }));
+  fireEvent.click(screen.getByRole("button", { name: /Bearbeiten/i }));
+  fireEvent.change(screen.getByLabelText(/Beschreibung/i), {
+    target: { value: "Tea" },
+  });
+  fireEvent.change(screen.getByLabelText(/Betrag/i), {
+    target: { value: "4" },
+  });
+  fireEvent.click(screen.getByRole("button", { name: /Hinzufügen/i }));
 
-  await waitFor(() => expect(UpdateExpense).toHaveBeenCalledWith(1, 1, 'Tea', 4));
-  expect(await screen.findByText('Tea')).toBeInTheDocument();
+  await waitFor(() =>
+    expect(UpdateExpense).toHaveBeenCalledWith(1, 1, "Tea", 4),
+  );
+  expect(await screen.findByText("Tea")).toBeInTheDocument();
 });
 
 // Delete Expense
 
-test('deletes an expense', async () => {
+test("deletes an expense", async () => {
   ListIncomes.mockResolvedValueOnce([]);
-  ListExpenses.mockResolvedValueOnce([{ id: 1, description: 'Coffee', amount: 3 }]).mockResolvedValueOnce([]);
+  ListExpenses.mockResolvedValueOnce([
+    { id: 1, description: "Coffee", amount: 3 },
+  ]).mockResolvedValueOnce([]);
   ListMembers.mockResolvedValueOnce([]);
   DeleteExpense.mockResolvedValueOnce();
-  render(<App />);
-  await screen.findByRole('heading', { name: /Baristeuer/i });
-  fireEvent.click(screen.getByRole('tab', { name: /Ausgaben/i }));
-  await screen.findByText('Coffee');
+  await login();
+  fireEvent.click(screen.getByRole("tab", { name: /Ausgaben/i }));
+  await screen.findByText("Coffee");
 
-  fireEvent.click(screen.getByRole('button', { name: /Löschen/i }));
+  fireEvent.click(screen.getByRole("button", { name: /Löschen/i }));
 
   await waitFor(() => expect(DeleteExpense).toHaveBeenCalledWith(1));
-  await waitFor(() => expect(screen.queryByText('Coffee')).not.toBeInTheDocument());
+  await waitFor(() =>
+    expect(screen.queryByText("Coffee")).not.toBeInTheDocument(),
+  );
 });
 
 // Calculate taxes
 
-test('shows tax calculation result', async () => {
+test("shows tax calculation result", async () => {
   ListExpenses.mockResolvedValueOnce([]);
   ListIncomes.mockResolvedValueOnce([]);
   ListMembers.mockResolvedValueOnce([]);
-  CalculateProjectTaxes.mockResolvedValueOnce({ revenue: 100, expenses: 20, taxableIncome: 80, totalTax: 10 });
-  render(<App />);
-  await screen.findByRole('heading', { name: /Baristeuer/i });
+  CalculateProjectTaxes.mockResolvedValueOnce({
+    revenue: 100,
+    expenses: 20,
+    taxableIncome: 80,
+    totalTax: 10,
+  });
+  await login();
 
-  fireEvent.click(screen.getByRole('tab', { name: /Steuern/i }));
-  fireEvent.click(screen.getByRole('button', { name: /Steuern berechnen/i }));
+  fireEvent.click(screen.getByRole("tab", { name: /Steuern/i }));
+  fireEvent.click(screen.getByRole("button", { name: /Steuern berechnen/i }));
 
-  expect(await screen.findByText('Einnahmen: 100.00 \u20AC')).toBeInTheDocument();
-  expect(screen.getByText('Ausgaben: 20.00 \u20AC')).toBeInTheDocument();
-  expect(screen.getByText('Steuerpflichtiges Einkommen: 80.00 \u20AC')).toBeInTheDocument();
-  expect(screen.getByText('Gesamtsteuer: 10.00 \u20AC')).toBeInTheDocument();
+  expect(
+    await screen.findByText("Einnahmen: 100.00 \u20AC"),
+  ).toBeInTheDocument();
+  expect(screen.getByText("Ausgaben: 20.00 \u20AC")).toBeInTheDocument();
+  expect(
+    screen.getByText("Steuerpflichtiges Einkommen: 80.00 \u20AC"),
+  ).toBeInTheDocument();
+  expect(screen.getByText("Gesamtsteuer: 10.00 \u20AC")).toBeInTheDocument();
 });
 
 // Add member
 
-test('adds a new member', async () => {
+test("adds a new member", async () => {
   ListExpenses.mockResolvedValueOnce([]);
   ListIncomes.mockResolvedValueOnce([]);
-  ListMembers.mockResolvedValueOnce([]).mockResolvedValueOnce([{ id: 1, name: 'Alice', email: 'a@example.com', joinDate: '2024-01-10' }]);
+  ListMembers.mockResolvedValueOnce([]).mockResolvedValueOnce([
+    { id: 1, name: "Alice", email: "a@example.com", joinDate: "2024-01-10" },
+  ]);
   AddMember.mockResolvedValueOnce();
-  render(<App />);
-  await screen.findByRole('heading', { name: /Baristeuer/i });
+  await login();
 
-  fireEvent.click(screen.getByRole('tab', { name: /Mitglieder/i }));
-  fireEvent.change(screen.getByLabelText(/Name/i), { target: { value: 'Alice' } });
-  fireEvent.change(screen.getByLabelText(/E-Mail/i), { target: { value: 'a@example.com' } });
-  fireEvent.change(screen.getByLabelText(/Beitrittsdatum/i), { target: { value: '2024-01-10' } });
-  fireEvent.click(screen.getByRole('button', { name: /Hinzufügen/i }));
+  fireEvent.click(screen.getByRole("tab", { name: /Mitglieder/i }));
+  fireEvent.change(screen.getByLabelText(/Name/i), {
+    target: { value: "Alice" },
+  });
+  fireEvent.change(screen.getByLabelText(/E-Mail/i), {
+    target: { value: "a@example.com" },
+  });
+  fireEvent.change(screen.getByLabelText(/Beitrittsdatum/i), {
+    target: { value: "2024-01-10" },
+  });
+  fireEvent.click(screen.getByRole("button", { name: /Hinzufügen/i }));
 
-  await waitFor(() => expect(AddMember).toHaveBeenCalledWith('Alice', 'a@example.com', '2024-01-10'));
-  expect(await screen.findByText('Alice')).toBeInTheDocument();
+  await waitFor(() =>
+    expect(AddMember).toHaveBeenCalledWith(
+      "Alice",
+      "a@example.com",
+      "2024-01-10",
+    ),
+  );
+  expect(await screen.findByText("Alice")).toBeInTheDocument();
 });
 
 // Delete member
 
-test('deletes a member', async () => {
+test("deletes a member", async () => {
   ListExpenses.mockResolvedValueOnce([]);
   ListIncomes.mockResolvedValueOnce([]);
-  ListMembers.mockResolvedValueOnce([{ id: 1, name: 'Bob', email: 'b@example.com', joinDate: '2024-01-05' }]).mockResolvedValueOnce([]);
+  ListMembers.mockResolvedValueOnce([
+    { id: 1, name: "Bob", email: "b@example.com", joinDate: "2024-01-05" },
+  ]).mockResolvedValueOnce([]);
   DeleteMember.mockResolvedValueOnce();
-  render(<App />);
-  await screen.findByRole('heading', { name: /Baristeuer/i });
+  await login();
 
-  fireEvent.click(screen.getByRole('tab', { name: /Mitglieder/i }));
-  await screen.findByText('Bob');
+  fireEvent.click(screen.getByRole("tab", { name: /Mitglieder/i }));
+  await screen.findByText("Bob");
 
-  fireEvent.click(screen.getByRole('button', { name: /Löschen/i }));
+  fireEvent.click(screen.getByRole("button", { name: /Löschen/i }));
 
   await waitFor(() => expect(DeleteMember).toHaveBeenCalledWith(1));
-  await waitFor(() => expect(screen.queryByText('Bob')).not.toBeInTheDocument());
+  await waitFor(() =>
+    expect(screen.queryByText("Bob")).not.toBeInTheDocument(),
+  );
 });

--- a/internal/ui/src/components/LoginPanel.jsx
+++ b/internal/ui/src/components/LoginPanel.jsx
@@ -1,0 +1,50 @@
+import { useState } from "react";
+import { Box, TextField, Button, Typography } from "@mui/material";
+import { useTranslation } from "react-i18next";
+import { Login, Register } from "../wailsjs/go/service/DataService";
+
+export default function LoginPanel({ onLoggedIn }) {
+  const [user, setUser] = useState("");
+  const [pass, setPass] = useState("");
+  const [error, setError] = useState("");
+  const { t } = useTranslation();
+
+  const handle = async (fn) => {
+    try {
+      await fn(user, pass);
+      setError("");
+      onLoggedIn && onLoggedIn();
+    } catch (e) {
+      setError(e.message || t("login.error"));
+    }
+  };
+
+  return (
+    <Box sx={{ mt: 4 }}>
+      <Box display="flex" gap={2} mb={2}>
+        <TextField
+          label={t("login.username")}
+          value={user}
+          onChange={(e) => setUser(e.target.value)}
+        />
+        <TextField
+          label={t("login.password")}
+          type="password"
+          value={pass}
+          onChange={(e) => setPass(e.target.value)}
+        />
+      </Box>
+      <Button variant="contained" onClick={() => handle(Login)} sx={{ mr: 2 }}>
+        {t("login.login")}
+      </Button>
+      <Button variant="outlined" onClick={() => handle(Register)}>
+        {t("login.register")}
+      </Button>
+      {error && (
+        <Typography color="error" sx={{ mt: 2 }}>
+          {error}
+        </Typography>
+      )}
+    </Box>
+  );
+}

--- a/internal/ui/src/components/LoginPanel.test.jsx
+++ b/internal/ui/src/components/LoginPanel.test.jsx
@@ -1,0 +1,28 @@
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import { vi } from "vitest";
+import LoginPanel from "./LoginPanel";
+import "../i18n";
+
+vi.mock(
+  "../wailsjs/go/service/DataService",
+  () => ({
+    Login: vi.fn().mockResolvedValue(),
+    Register: vi.fn().mockResolvedValue(),
+  }),
+  { virtual: true },
+);
+
+import { Login, Register } from "../wailsjs/go/service/DataService";
+
+test("calls login function", async () => {
+  render(<LoginPanel onLoggedIn={() => {}} />);
+  fireEvent.change(screen.getByLabelText(/Benutzer/i), {
+    target: { value: "a" },
+  });
+  fireEvent.change(screen.getByLabelText(/Passwort/i), {
+    target: { value: "b" },
+  });
+  fireEvent.click(screen.getByRole("button", { name: /Anmelden/i }));
+  await waitFor(() => expect(Login).toHaveBeenCalledWith("a", "b"));
+});

--- a/internal/ui/src/locales/de.json
+++ b/internal/ui/src/locales/de.json
@@ -98,5 +98,12 @@
   "language_en": "Englisch",
   "edit": "Bearbeiten",
   "delete": "Löschen",
-  "add_error": "Fehler beim Hinzufügen"
+  "add_error": "Fehler beim Hinzufügen",
+  "login": {
+    "username": "Benutzer",
+    "password": "Passwort",
+    "login": "Anmelden",
+    "register": "Registrieren",
+    "error": "Anmeldung fehlgeschlagen"
+  }
 }

--- a/internal/ui/src/locales/en.json
+++ b/internal/ui/src/locales/en.json
@@ -98,5 +98,12 @@
   "language_en": "English",
   "edit": "Edit",
   "delete": "Delete",
-  "add_error": "Error adding item"
+  "add_error": "Error adding item",
+  "login": {
+    "username": "Username",
+    "password": "Password",
+    "login": "Login",
+    "register": "Register",
+    "error": "Login failed"
+  }
 }

--- a/internal/ui/src/wailsjs/go/service/DataService.js
+++ b/internal/ui/src/wailsjs/go/service/DataService.js
@@ -85,3 +85,15 @@ export function SetLogLevel(arg1) {
 export function ExportProjectCSV(arg1, arg2) {
   return window.go.service.DataService.ExportProjectCSV(arg1, arg2);
 }
+
+export function Login(arg1, arg2) {
+  return window.go.service.DataService.Login(arg1, arg2);
+}
+
+export function Register(arg1, arg2) {
+  return window.go.service.DataService.Register(arg1, arg2);
+}
+
+export function Logout() {
+  return window.go.service.DataService.Logout();
+}


### PR DESCRIPTION
## Summary
- add User model and user management tables
- support optional user ID on projects with helper methods
- provide registration, login and logout in service layer
- restrict data access by logged-in user
- add frontend login panel and translations
- update tests for authentication handling

## Testing
- `go test ./cmd/... ./internal/... ./internal/pdf/...`
- `npm ci --prefix internal/ui`
- `npm test --prefix internal/ui`

------
https://chatgpt.com/codex/tasks/task_e_686941838ba483339cf18d4b4fad031b