### PR TITLE
Fix workflow dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,9 @@ jobs:
         with:
           go-version: '1.22'
 
+      - name: Sync Go workspace
+        run: go work sync
+
       - name: Setup Node
         uses: actions/setup-node@v3
         with:


### PR DESCRIPTION
## Summary
- sync Go workspace in CI

## Testing
- `npm test --prefix internal/ui`
- `go test ./cmd/... ./internal/... ./internal/pdf/...` *(fails: not enough arguments in call to `NewGenerator`)*

------
https://chatgpt.com/codex/tasks/task_e_686959174d8c8333b6fea9494baaa210