### PR TITLE
Fix generator tests and config fields

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -9,22 +9,28 @@ import (
 
 // Config holds application configuration values.
 type Config struct {
-	DBPath        string `json:"dbPath"`
-	PDFDir        string `json:"pdfDir"`
-	LogFile       string `json:"logFile"`
-	LogLevel      string `json:"logLevel"`
-	TaxYear       int    `json:"taxYear"`
-	FormName      string `json:"formName"`
-	FormTaxNumber string `json:"formTaxNumber"`
-	FormAddress   string `json:"formAddress"`
+	DBPath          string `json:"dbPath"`
+	PDFDir          string `json:"pdfDir"`
+	LogFile         string `json:"logFile"`
+	LogLevel        string `json:"logLevel"`
+	TaxYear         int    `json:"taxYear"`
+	FormName        string `json:"formName"`
+	FormTaxNumber   string `json:"formTaxNumber"`
+	FormAddress     string `json:"formAddress"`
+	FormCity        string `json:"formCity"`
+	FormBankAccount string `json:"formBankAccount"`
+	FormActivity    string `json:"formActivity"`
 }
 
 // DefaultConfig provides sensible defaults for a new configuration file.
 var DefaultConfig = Config{
-	DBPath:   "baristeuer.db",
-	PDFDir:   filepath.Join(".", "internal", "data", "reports"),
-	LogFile:  "baristeuer.log",
-	LogLevel: "info",
+	DBPath:          "baristeuer.db",
+	PDFDir:          filepath.Join(".", "internal", "data", "reports"),
+	LogFile:         "baristeuer.log",
+	LogLevel:        "info",
+	FormCity:        "",
+	FormBankAccount: "",
+	FormActivity:    "",
 }
 
 // Load reads configuration from the given file path. If the file does not exist,

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -18,7 +18,10 @@ func TestLoadFromFile(t *testing.T) {
         "taxYear": 2026,
         "formName": "Club",
         "formTaxNumber": "11/111/11111",
-        "formAddress": "Street 1"
+        "formAddress": "Street 1",
+        "formCity": "Town",
+        "formBankAccount": "DE00",
+        "formActivity": "Sport"
     }`
 	if err := os.WriteFile(path, []byte(data), 0o644); err != nil {
 		t.Fatal(err)
@@ -29,7 +32,8 @@ func TestLoadFromFile(t *testing.T) {
 		t.Fatalf("Load returned error: %v", err)
 	}
 	if cfg.DBPath != "db.sqlite" || cfg.PDFDir != "./pdfs" || cfg.LogFile != "app.log" || cfg.LogLevel != "debug" ||
-		cfg.TaxYear != 2026 || cfg.FormName != "Club" || cfg.FormTaxNumber != "11/111/11111" || cfg.FormAddress != "Street 1" {
+		cfg.TaxYear != 2026 || cfg.FormName != "Club" || cfg.FormTaxNumber != "11/111/11111" || cfg.FormAddress != "Street 1" ||
+		cfg.FormCity != "Town" || cfg.FormBankAccount != "DE00" || cfg.FormActivity != "Sport" {
 		t.Fatalf("unexpected config: %+v", cfg)
 	}
 }
@@ -53,7 +57,7 @@ func TestLoadMissingFile(t *testing.T) {
 func TestSaveAndVerify(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "out.json")
-	expected := Config{DBPath: "db", PDFDir: "pdf", LogFile: "log", LogLevel: "info", TaxYear: 2025, FormName: "Org", FormTaxNumber: "12/222/22222", FormAddress: "Main"}
+	expected := Config{DBPath: "db", PDFDir: "pdf", LogFile: "log", LogLevel: "info", TaxYear: 2025, FormName: "Org", FormTaxNumber: "12/222/22222", FormAddress: "Main", FormCity: "Town", FormBankAccount: "DE00", FormActivity: "Sport"}
 
 	if err := Save(path, expected); err != nil {
 		t.Fatalf("Save returned error: %v", err)

--- a/internal/pdf/pdf.go
+++ b/internal/pdf/pdf.go
@@ -88,10 +88,13 @@ func (g *Generator) SetTaxYear(year int) {
 
 func (g *Generator) formInfo() FormInfo {
 	return FormInfo{
-		Name:       g.cfg.FormName,
-		TaxNumber:  g.cfg.FormTaxNumber,
-		Address:    g.cfg.FormAddress,
-		FiscalYear: fmt.Sprintf("%d", g.cfg.TaxYear),
+		Name:        g.cfg.FormName,
+		TaxNumber:   g.cfg.FormTaxNumber,
+		Address:     g.cfg.FormAddress,
+		City:        g.cfg.FormCity,
+		BankAccount: g.cfg.FormBankAccount,
+		Activity:    g.cfg.FormActivity,
+		FiscalYear:  fmt.Sprintf("%d", g.cfg.TaxYear),
 	}
 }
 
@@ -198,7 +201,6 @@ func (g *Generator) GenerateKSt1(projectID int64) (string, error) {
 	if err := info.Validate(); err != nil {
 		return "", err
 	}
-
 
 	revenue, err := g.store.SumIncomeByProject(ctx, projectID)
 	if err != nil {
@@ -338,7 +340,6 @@ func (g *Generator) GenerateAnlageGem(projectID int64) (string, error) {
 	if err := info.Validate(); err != nil {
 		return "", err
 	}
-
 
 	revenue, err := g.store.SumIncomeByProject(ctx, projectID)
 	if err != nil {

--- a/internal/pdf/pdf_test.go
+++ b/internal/pdf/pdf_test.go
@@ -86,16 +86,16 @@ func TestFormGeneration(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	g := NewGenerator(dir, store)
-	info := FormInfo{
-		Name:        "Testverein",
-		TaxNumber:   "11/111/11111",
-		Address:     "Hauptstr. 1",
-		City:        "Musterstadt",
-		BankAccount: "DE00 0000 0000 0000 0000 00",
-		Activity:    "Sport",
-		FiscalYear:  "2025",
+	cfg := config.Config{
+		FormName:        "Testverein",
+		FormTaxNumber:   "11/111/11111",
+		FormAddress:     "Hauptstr. 1",
+		FormCity:        "Musterstadt",
+		FormBankAccount: "DE00 0000 0000 0000 0000 00",
+		FormActivity:    "Sport",
+		TaxYear:         2025,
 	}
+	g := NewGenerator(dir, store, &cfg)
 
 	files := []struct {
 		name     string


### PR DESCRIPTION
## Summary
- update `Config` with extra form fields
- wire new form fields into PDF generator
- fix tests to use updated configuration

## Testing
- `go vet ./cmd/... ./internal/... ./internal/pdf/...`
- `go test ./cmd/... ./internal/... ./internal/pdf/...`

------
https://chatgpt.com/codex/tasks/task_e_68695914b0dc8333819c43a50cc8cd21