### PR TITLE
Clean up unused CSS classes

### DIFF
--- a/internal/ui/src/App.css
+++ b/internal/ui/src/App.css
@@ -5,38 +5,6 @@
   text-align: center;
 }
 
-.logo {
-  height: 6em;
-  padding: 1.5em;
-  will-change: filter;
-  transition: filter 300ms;
-}
-.logo:hover {
-  filter: drop-shadow(0 0 2em #646cffaa);
-}
-.logo.react:hover {
-  filter: drop-shadow(0 0 2em #61dafbaa);
-}
-
-@keyframes logo-spin {
-  from {
-    transform: rotate(0deg);
-  }
-  to {
-    transform: rotate(360deg);
-  }
-}
-
-@media (prefers-reduced-motion: no-preference) {
-  a:nth-of-type(2) .logo {
-    animation: logo-spin infinite 20s linear;
-  }
-}
-
 .card {
   padding: 2em;
-}
-
-.read-the-docs {
-  color: #888;
 }


### PR DESCRIPTION
## Summary
- remove default logo and docs styles from `App.css`
- verified that `npm run build --prefix internal/ui` completes without CSS-related warnings

## Testing
- `npm run build --prefix internal/ui`

------
https://chatgpt.com/codex/tasks/task_e_686982eec0cc83339a0e5117664323d3