### PR TITLE
Add Docker build setup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,34 @@
+FROM golang:1.22-bullseye AS build
+
+# Install Node.js and npm
+RUN apt-get update && apt-get install -y nodejs npm && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+# Copy go work files and modules
+COPY go.work go.work.sum ./
+COPY cmd/go.mod cmd/go.sum ./cmd/
+COPY internal/go.mod internal/go.sum ./internal/
+COPY internal/pdf/go.mod internal/pdf/go.sum ./internal/pdf/
+
+# Synchronize workspace modules
+RUN go work sync
+
+# Copy the rest of the repository
+COPY . .
+
+# Install frontend dependencies and build the UI
+RUN npm ci --prefix internal/ui
+RUN npm run build --prefix internal/ui
+
+# Install Wails CLI and build the application
+RUN go install github.com/wailsapp/wails/v2/cmd/wails@latest
+RUN wails build -clean
+
+FROM debian:bullseye-slim AS final
+WORKDIR /app
+
+# Copy built binary
+COPY --from=build /app/build/bin/ /app/
+
+CMD ["./Bari$teuer"]

--- a/README.md
+++ b/README.md
@@ -113,6 +113,18 @@ in versioned directories under `build/bin`:
 The script uses `wails build` internally and names the output directory after the
 current Git tag or commit hash.
 
+## Docker
+
+You can also build Bari$teuer inside a container. Example commands:
+
+```bash
+# Build the image
+docker build -t baristeuer .
+
+# Run the resulting binary
+docker run --rm baristeuer
+```
+
 ---
 
 _This project is for internal use and is not open for contributions._


### PR DESCRIPTION
## Summary
- add Dockerfile for building the app using Go, Node and Wails
- document docker build/run usage in the README

## Testing
- `go test ./cmd/... ./internal/... ./internal/pdf/...`
- `npm test --prefix internal/ui`


------
https://chatgpt.com/codex/tasks/task_e_686982eb3d4c83338bb458577630f1f4