### PR TITLE
Add React component tests

### DIFF
--- a/internal/ui/src/components/ExpenseForm.test.jsx
+++ b/internal/ui/src/components/ExpenseForm.test.jsx
@@ -1,0 +1,29 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import ExpenseForm from './ExpenseForm';
+import '../i18n';
+
+const onSubmit = vi.fn();
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+test('shows validation errors', async () => {
+  render(<ExpenseForm onSubmit={onSubmit} />);
+  fireEvent.click(screen.getByRole('button', { name: /Hinzufügen/i }));
+  expect(await screen.findByText(/Beschreibung und Betrag erforderlich/i)).toBeInTheDocument();
+
+  fireEvent.change(screen.getByLabelText(/Beschreibung/i), { target: { value: 'Fee' } });
+  fireEvent.change(screen.getByLabelText(/Betrag/i), { target: { value: '-1' } });
+  fireEvent.click(screen.getByRole('button', { name: /Hinzufügen/i }));
+  expect(await screen.findByText(/Betrag muss eine positive Zahl sein/i)).toBeInTheDocument();
+});
+
+test('submits valid data', async () => {
+  render(<ExpenseForm onSubmit={onSubmit} />);
+  fireEvent.change(screen.getByLabelText(/Beschreibung/i), { target: { value: 'Rent' } });
+  fireEvent.change(screen.getByLabelText(/Betrag/i), { target: { value: '5' } });
+  fireEvent.click(screen.getByRole('button', { name: /Hinzufügen/i }));
+  expect(onSubmit).toHaveBeenCalled();
+});

--- a/internal/ui/src/components/IncomeForm.test.jsx
+++ b/internal/ui/src/components/IncomeForm.test.jsx
@@ -1,0 +1,29 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import IncomeForm from './IncomeForm';
+import '../i18n';
+
+const onSubmit = vi.fn();
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+test('shows validation errors', async () => {
+  render(<IncomeForm onSubmit={onSubmit} />);
+  fireEvent.click(screen.getByRole('button', { name: /Hinzufügen/i }));
+  expect(await screen.findByText(/Quelle und Betrag erforderlich/i)).toBeInTheDocument();
+
+  fireEvent.change(screen.getByLabelText(/Quelle/i), { target: { value: 'Sponsor' } });
+  fireEvent.change(screen.getByLabelText(/Betrag/i), { target: { value: '-5' } });
+  fireEvent.click(screen.getByRole('button', { name: /Hinzufügen/i }));
+  expect(await screen.findByText(/Betrag muss eine positive Zahl sein/i)).toBeInTheDocument();
+});
+
+test('submits valid data', async () => {
+  render(<IncomeForm onSubmit={onSubmit} />);
+  fireEvent.change(screen.getByLabelText(/Quelle/i), { target: { value: 'Job' } });
+  fireEvent.change(screen.getByLabelText(/Betrag/i), { target: { value: '10' } });
+  fireEvent.click(screen.getByRole('button', { name: /Hinzufügen/i }));
+  expect(onSubmit).toHaveBeenCalled();
+});

--- a/internal/ui/src/components/MemberTable.test.jsx
+++ b/internal/ui/src/components/MemberTable.test.jsx
@@ -1,0 +1,22 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import MemberTable from './MemberTable';
+import '../i18n';
+
+const onDelete = vi.fn();
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+test('renders empty state', () => {
+  render(<MemberTable members={[]} onDelete={onDelete} />);
+  expect(screen.getByText(/Keine Mitglieder vorhanden/i)).toBeInTheDocument();
+});
+
+test('calls delete callback', () => {
+  const members = [{ id: 1, name: 'Alice', email: 'a@example.com', joinDate: '2024-01-01' }];
+  render(<MemberTable members={members} onDelete={onDelete} />);
+  fireEvent.click(screen.getByRole('button', { name: /Löschen/i }));
+  expect(onDelete).toHaveBeenCalledWith(1);
+});


### PR DESCRIPTION
## Summary
- add `IncomeForm.test.jsx` for form validation and submit calls
- add `ExpenseForm.test.jsx` for form validation and submit calls
- add `MemberTable.test.jsx` to verify delete callback
- run `npm test` in `internal/ui`

## Testing
- `npm test --prefix internal/ui`

------
https://chatgpt.com/codex/tasks/task_e_686982e7c1d483338cf9491b1224e503