### PR TITLE
Honor BARISTEUER_PDFDIR env var

### DIFF
--- a/internal/pdf/pdf.go
+++ b/internal/pdf/pdf.go
@@ -63,7 +63,9 @@ func NewGenerator(basePath string, store *data.Store, cfg *config.Config) *Gener
 		cfg = &config.Config{}
 	}
 	if basePath == "" {
-		if cfg.PDFDir != "" {
+		if env := os.Getenv("BARISTEUER_PDFDIR"); env != "" {
+			basePath = env
+		} else if cfg.PDFDir != "" {
 			basePath = cfg.PDFDir
 		} else {
 			basePath = config.DefaultConfig.PDFDir

--- a/internal/pdf/pdf_test.go
+++ b/internal/pdf/pdf_test.go
@@ -21,6 +21,15 @@ func TestNewGenerator(t *testing.T) {
 	}
 }
 
+func TestNewGeneratorEnvFallback(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("BARISTEUER_PDFDIR", dir)
+	g := NewGenerator("", nil, &config.Config{})
+	if g.BasePath != dir {
+		t.Fatalf("expected %s, got %s", dir, g.BasePath)
+	}
+}
+
 func TestGenerateReport(t *testing.T) {
 	dir := t.TempDir()
 	store, err := data.NewStore(":memory:")


### PR DESCRIPTION
## Summary
- prefer `BARISTEUER_PDFDIR` over config when creating PDF generator
- test environment variable fallback in `NewGenerator`

## Testing
- `go test ./cmd/... ./internal/... ./internal/pdf/...`


------
https://chatgpt.com/codex/tasks/task_e_686982e6ed5083339c7495ba1d934b3f