### PR TITLE
Fix Load not returning Save error

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -39,7 +39,7 @@ func Load(path string) (Config, error) {
 		if os.IsNotExist(err) {
 			cfg = DefaultConfig
 			if err := Save(path, cfg); err != nil {
-				return cfg, nil
+				return cfg, fmt.Errorf("save config: %w", err)
 			}
 			return cfg, nil
 		}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -72,3 +72,12 @@ func TestSaveAndVerify(t *testing.T) {
 		t.Fatalf("written config mismatch: %+v vs %+v", got, expected)
 	}
 }
+
+func TestLoadSaveError(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "missing", "config.json")
+
+	if _, err := Load(path); err == nil {
+		t.Fatal("expected error, got nil")
+	}
+}


### PR DESCRIPTION
## Summary
- propagate errors when saving default config fails in `Load`
- add unit test for failed Save during Load

## Testing
- `go test ./...` in internal module
- `go test ./...` in cmd module
- `go test ./...` in internal/pdf

------
https://chatgpt.com/codex/tasks/task_e_686982e59a8c8333adb45fb0afe2cbfb