### PR TITLE
Handle per-panel errors and extend tests

### DIFF
--- a/internal/ui/src/App.jsx
+++ b/internal/ui/src/App.jsx
@@ -26,9 +26,11 @@ export default function App() {
   const [projectId, setProjectId] = useState(1);
   const { t, i18n } = useTranslation();
   const [language, setLanguage] = useState(i18n.language);
-  const [error, setError] = useState("");
-  const handleError = (err, key = 'errors.add') => {
-    setError(err.message || t(key));
+  const [incomeError, setIncomeError] = useState("");
+  const [expenseError, setExpenseError] = useState("");
+  const [memberError, setMemberError] = useState("");
+  const handleError = (err, setter, key = 'errors.add') => {
+    setter(err.message || t(key));
   };
 
   const theme = createTheme({
@@ -77,7 +79,7 @@ export default function App() {
       setError("");
       fetchIncomes();
     } catch (err) {
-      handleError(err);
+      handleError(err, setIncomeError);
     }
   };
 
@@ -92,7 +94,7 @@ export default function App() {
       setError("");
       fetchExpenses();
     } catch (err) {
-      handleError(err);
+      handleError(err, setExpenseError);
     }
   };
 
@@ -102,7 +104,7 @@ export default function App() {
       setError("");
       fetchMembers();
     } catch (err) {
-      handleError(err);
+      handleError(err, setMemberError);
     }
   };
 
@@ -214,9 +216,19 @@ export default function App() {
           </Paper>
         )}
       </Container>
-      <Snackbar open={!!error} autoHideDuration={6000} onClose={() => setError('')}>
-        <Alert severity="error" onClose={() => setError('')}>
-          {error}
+      <Snackbar open={!!incomeError} autoHideDuration={6000} onClose={() => setIncomeError('')}>
+        <Alert severity="error" onClose={() => setIncomeError('')}>
+          {incomeError}
+        </Alert>
+      </Snackbar>
+      <Snackbar open={!!expenseError} autoHideDuration={6000} onClose={() => setExpenseError('')}>
+        <Alert severity="error" onClose={() => setExpenseError('')}>
+          {expenseError}
+        </Alert>
+      </Snackbar>
+      <Snackbar open={!!memberError} autoHideDuration={6000} onClose={() => setMemberError('')}>
+        <Alert severity="error" onClose={() => setMemberError('')}>
+          {memberError}
         </Alert>
       </Snackbar>
     </ThemeProvider>

--- a/internal/ui/src/components/ExpenseForm.test.jsx
+++ b/internal/ui/src/components/ExpenseForm.test.jsx
@@ -27,3 +27,14 @@ test('submits valid data', async () => {
   fireEvent.click(screen.getByRole('button', { name: /Hinzufügen/i }));
   expect(onSubmit).toHaveBeenCalled();
 });
+
+test('shows submit error', async () => {
+  onSubmit.mockImplementation(async (_d, _a, setErr) => {
+    setErr('fail');
+  });
+  render(<ExpenseForm onSubmit={onSubmit} />);
+  fireEvent.change(screen.getByLabelText(/Beschreibung/i), { target: { value: 'X' } });
+  fireEvent.change(screen.getByLabelText(/Betrag/i), { target: { value: '1' } });
+  fireEvent.click(screen.getByRole('button', { name: /Hinzufügen/i }));
+  expect(await screen.findByText('fail')).toBeInTheDocument();
+});

--- a/internal/ui/src/components/IncomeForm.test.jsx
+++ b/internal/ui/src/components/IncomeForm.test.jsx
@@ -27,3 +27,14 @@ test('submits valid data', async () => {
   fireEvent.click(screen.getByRole('button', { name: /Hinzufügen/i }));
   expect(onSubmit).toHaveBeenCalled();
 });
+
+test('shows submit error', async () => {
+  onSubmit.mockImplementation(async (_s, _a, setErr) => {
+    setErr('fail');
+  });
+  render(<IncomeForm onSubmit={onSubmit} />);
+  fireEvent.change(screen.getByLabelText(/Quelle/i), { target: { value: 'Foo' } });
+  fireEvent.change(screen.getByLabelText(/Betrag/i), { target: { value: '2' } });
+  fireEvent.click(screen.getByRole('button', { name: /Hinzufügen/i }));
+  expect(await screen.findByText('fail')).toBeInTheDocument();
+});

--- a/internal/ui/src/components/MemberForm.test.jsx
+++ b/internal/ui/src/components/MemberForm.test.jsx
@@ -26,3 +26,14 @@ test('submits valid data', async () => {
   fireEvent.click(screen.getByRole('button', { name: /Hinzufügen/i }));
   expect(onSubmit).toHaveBeenCalled();
 });
+
+test('shows submit error', async () => {
+  onSubmit.mockImplementation(async (_n, _e, _d, setErr) => {
+    setErr('fail');
+  });
+  render(<MemberForm onSubmit={onSubmit} />);
+  fireEvent.change(screen.getByLabelText(/Name/i), { target: { value: 'Bob' } });
+  fireEvent.change(screen.getByLabelText(/E-Mail/i), { target: { value: 'bob@example.com' } });
+  fireEvent.click(screen.getByRole('button', { name: /Hinzufügen/i }));
+  expect(await screen.findByText('fail')).toBeInTheDocument();
+});

--- a/internal/ui/src/components/ProjectPanel.test.jsx
+++ b/internal/ui/src/components/ProjectPanel.test.jsx
@@ -60,4 +60,14 @@ test('deletes a project', async () => {
   await waitFor(() => expect(screen.queryByText('Alpha')).not.toBeInTheDocument());
 });
 
+test('shows create error', async () => {
+  ListProjects.mockResolvedValueOnce([]);
+  CreateProject.mockRejectedValueOnce(new Error('fail'));
+  render(<ProjectPanel activeId={0} />);
+  await screen.findByRole('textbox', { name: /Neues Projekt/i });
+  fireEvent.change(screen.getByLabelText(/Neues Projekt/i), { target: { value: 'Foo' } });
+  fireEvent.click(screen.getByRole('button', { name: /Erstellen/i }));
+  expect(await screen.findByText('fail')).toBeInTheDocument();
+});
+
 

--- a/internal/ui/src/components/SettingsPanel.jsx
+++ b/internal/ui/src/components/SettingsPanel.jsx
@@ -6,6 +6,7 @@ import {
   Select,
   MenuItem,
   Typography,
+  Alert,
 } from "@mui/material";
 import { useTranslation } from "react-i18next";
 import {
@@ -23,43 +24,43 @@ export default function SettingsPanel({ projectId }) {
   const [csvPath, setCsvPath] = useState("");
   const [level, setLevel] = useState("info");
   const [taxYear, setTaxYear] = useState(2025);
-  const [msg, setMsg] = useState("");
+  const [feedback, setFeedback] = useState({ type: "", text: "" });
 
   const doExport = async () => {
     try {
       await ExportDatabase(exportPath);
-      setMsg(t("settings.exported"));
+      setFeedback({ type: "success", text: t("settings.exported") });
     } catch (e) {
-      setMsg(String(e));
+      setFeedback({ type: "error", text: String(e) });
     }
   };
 
   const doRestore = async () => {
     try {
       await RestoreDatabase(restorePath);
-      setMsg(t("settings.restored"));
+      setFeedback({ type: "success", text: t("settings.restored") });
     } catch (e) {
-      setMsg(String(e));
+      setFeedback({ type: "error", text: String(e) });
     }
   };
 
   const doExportCSV = async () => {
     try {
       await ExportProjectCSV(projectId, csvPath);
-      setMsg(t("settings.csv_exported"));
+      setFeedback({ type: "success", text: t("settings.csv_exported") });
     } catch (e) {
-      setMsg(String(e));
+      setFeedback({ type: "error", text: String(e) });
     }
   };
 
   const changeLevel = () => {
     SetLogLevel(level);
-    setMsg(t("settings.applied"));
+    setFeedback({ type: "success", text: t("settings.applied") });
   };
 
   const applyYear = () => {
     SetTaxYear(parseInt(taxYear));
-    setMsg(t("settings.applied"));
+    setFeedback({ type: "success", text: t("settings.applied") });
   };
 
   return (
@@ -127,10 +128,10 @@ export default function SettingsPanel({ projectId }) {
           {t("settings.apply")}
         </Button>
       </Box>
-      {msg && (
-        <Typography color="primary" sx={{ mt: 2 }}>
-          {msg}
-        </Typography>
+      {feedback.text && (
+        <Alert severity={feedback.type} sx={{ mt: 2 }}>
+          {feedback.text}
+        </Alert>
       )}
     </Box>
   );


### PR DESCRIPTION
## Summary
- maintain separate error states for income, expense and member panels
- consolidate settings feedback using severity alerts
- test error scenarios in component tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68698c89f4f48333bc8f727e96c3b271