### PR TITLE
Add 2027 tax config & JSON loading

### DIFF
--- a/internal/taxlogic/tax_logic.go
+++ b/internal/taxlogic/tax_logic.go
@@ -1,6 +1,10 @@
 package taxlogic
 
-import "time"
+import (
+	"encoding/json"
+	"os"
+	"time"
+)
 
 // TaxConfig holds the constants for a given tax year.
 type TaxConfig struct {
@@ -8,6 +12,20 @@ type TaxConfig struct {
 	ProfitAllowance         float64
 	CorporateTaxRate        float64
 	SolidaritySurchargeRate float64
+}
+
+// LoadConfig reads tax parameters from a JSON file.
+func LoadConfig(path string) (TaxConfig, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return TaxConfig{}, err
+	}
+	defer f.Close()
+	var cfg TaxConfig
+	if err := json.NewDecoder(f).Decode(&cfg); err != nil {
+		return TaxConfig{}, err
+	}
+	return cfg, nil
 }
 
 // DefaultConfig2025 returns the tax configuration for the year 2025.
@@ -30,9 +48,21 @@ func DefaultConfig2026() TaxConfig {
 	}
 }
 
+// DefaultConfig2027 returns the tax configuration for the year 2027.
+func DefaultConfig2027() TaxConfig {
+	return TaxConfig{
+		RevenueExemptionLimit:   45000.00,
+		ProfitAllowance:         5000.00,
+		CorporateTaxRate:        0.15,
+		SolidaritySurchargeRate: 0.055,
+	}
+}
+
 // defaultConfig returns the configuration for the given year, falling back to 2025.
 func defaultConfig(year int) TaxConfig {
 	switch year {
+	case 2027:
+		return DefaultConfig2027()
 	case 2026:
 		return DefaultConfig2026()
 	case 2025:

--- a/internal/taxlogic/tax_logic_test.go
+++ b/internal/taxlogic/tax_logic_test.go
@@ -3,6 +3,8 @@ package taxlogic
 import (
 	"fmt"
 	"math"
+	"os"
+	"path/filepath"
 	"testing"
 )
 
@@ -13,7 +15,7 @@ func floatEquals(a, b float64) bool {
 }
 
 func TestCalculateTaxes(t *testing.T) {
-	years := []int{2025, 2026}
+	years := []int{2025, 2026, 2027}
 	testCases := []struct {
 		name     string
 		revenue  float64
@@ -152,5 +154,27 @@ func TestCalculateTaxes(t *testing.T) {
 				}
 			})
 		}
+	}
+}
+
+func TestLoadConfig(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "tax.json")
+	data := `{
+               "RevenueExemptionLimit": 100,
+               "ProfitAllowance": 10,
+               "CorporateTaxRate": 0.2,
+               "SolidaritySurchargeRate": 0.1
+       }`
+	if err := os.WriteFile(path, []byte(data), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := LoadConfig(path)
+	if err != nil {
+		t.Fatalf("LoadConfig failed: %v", err)
+	}
+	if cfg.RevenueExemptionLimit != 100 || cfg.ProfitAllowance != 10 || cfg.CorporateTaxRate != 0.2 || cfg.SolidaritySurchargeRate != 0.1 {
+		t.Fatalf("config mismatch: %+v", cfg)
 	}
 }


### PR DESCRIPTION
## Summary
- extend taxlogic with a configuration for 2027
- support loading tax parameters from JSON
- test the new configuration loading and add coverage for tax year 2027

## Testing
- `go test ./cmd/... ./internal/... ./internal/pdf/...`


------
https://chatgpt.com/codex/tasks/task_e_68698c8d0f2c8333a0f7f4dbf3f1f93d