### PR TITLE
Add service benchmarks and profiling script

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,29 @@ in versioned directories under `build/bin`:
 The script uses `wails build` internally and names the output directory after the
 current Git tag or commit hash.
 
+## Benchmarking & Profiling
+
+Benchmarks cover mass insertion of incomes and expenses. Run them with:
+
+```bash
+go test ./internal/service -bench=Mass -benchmem
+```
+
+For CPU and memory profiles execute:
+
+```bash
+./scripts/profile_service.sh
+```
+
+Sample results on a linux/amd64 machine:
+
+```
+BenchmarkAddIncomeMass1e2-5    1132   996966 ns/op   55223 B/op   1500 allocs/op
+BenchmarkAddIncomeMass1e3-5     100  11604405 ns/op  552316 B/op  15001 allocs/op
+BenchmarkAddExpenseMass1e2-5   1230   968092 ns/op   55227 B/op   1500 allocs/op
+BenchmarkAddExpenseMass1e3-5    127  9727703 ns/op  552305 B/op  15001 allocs/op
+```
+
 ## Docker
 
 You can also build Bari$teuer inside a container. Example commands:

--- a/internal/service/service_benchmark_test.go
+++ b/internal/service/service_benchmark_test.go
@@ -1,0 +1,56 @@
+package service
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"testing"
+)
+
+func benchmarkAddIncome(b *testing.B, n int) {
+	ds, err := NewDataService(":memory:", slog.New(slog.NewTextHandler(io.Discard, nil)), nil)
+	if err != nil {
+		b.Fatal(err)
+	}
+	defer ds.Close()
+	ctx := context.Background()
+	proj, err := ds.CreateProject(ctx, "bench")
+	if err != nil {
+		b.Fatal(err)
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		for j := 0; j < n; j++ {
+			if _, err := ds.AddIncome(ctx, proj.ID, "donation", 1); err != nil {
+				b.Fatalf("add income: %v", err)
+			}
+		}
+	}
+}
+
+func BenchmarkAddIncomeMass1e2(b *testing.B) { benchmarkAddIncome(b, 100) }
+func BenchmarkAddIncomeMass1e3(b *testing.B) { benchmarkAddIncome(b, 1000) }
+
+func benchmarkAddExpense(b *testing.B, n int) {
+	ds, err := NewDataService(":memory:", slog.New(slog.NewTextHandler(io.Discard, nil)), nil)
+	if err != nil {
+		b.Fatal(err)
+	}
+	defer ds.Close()
+	ctx := context.Background()
+	proj, err := ds.CreateProject(ctx, "bench")
+	if err != nil {
+		b.Fatal(err)
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		for j := 0; j < n; j++ {
+			if _, err := ds.AddExpense(ctx, proj.ID, "rent", 1); err != nil {
+				b.Fatalf("add expense: %v", err)
+			}
+		}
+	}
+}
+
+func BenchmarkAddExpenseMass1e2(b *testing.B) { benchmarkAddExpense(b, 100) }
+func BenchmarkAddExpenseMass1e3(b *testing.B) { benchmarkAddExpense(b, 1000) }

--- a/scripts/profile_service.sh
+++ b/scripts/profile_service.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+# Run service benchmarks with CPU and memory profiling
+set -e
+cd "$(git rev-parse --show-toplevel)"
+PROFILE_DIR=${PROFILE_DIR:-bench_profiles}
+mkdir -p "$PROFILE_DIR"
+go test ./internal/service -bench=Mass -benchmem -cpuprofile "$PROFILE_DIR/cpu.out" -memprofile "$PROFILE_DIR/mem.out"
+cat <<MSG
+Profiles written to $PROFILE_DIR/cpu.out and $PROFILE_DIR/mem.out
+Use 'go tool pprof' to analyze the results, e.g.:
+  go tool pprof $PROFILE_DIR/cpu.out
+MSG


### PR DESCRIPTION
## Summary
- benchmark mass income/expense inserts in `DataService`
- add profiling helper script
- document benchmark usage and sample results in README

## Testing
- `go test ./cmd/... ./internal/... ./internal/pdf/...`
- `npm test --prefix internal/ui`
- `go test ./internal/service -bench=Mass -benchmem`

------
https://chatgpt.com/codex/tasks/task_e_68698c9940d88333b8e956965698ae81