### PR TITLE
Add context parameter to PDF generator

### DIFF
--- a/internal/pdf/pdf.go
+++ b/internal/pdf/pdf.go
@@ -116,8 +116,7 @@ func tableRow(pdf *gofpdf.Fpdf, widths []float64, values []string) {
 }
 
 // GenerateReport creates a tax report PDF for the given project.
-func (g *Generator) GenerateReport(projectID int64) (string, error) {
-	ctx := context.Background()
+func (g *Generator) GenerateReport(ctx context.Context, projectID int64) (string, error) {
 	revenue, err := g.store.SumIncomeByProject(ctx, projectID)
 	if err != nil {
 		return "", fmt.Errorf("fetch revenue: %w", err)
@@ -205,8 +204,7 @@ func (g *Generator) GenerateReport(projectID int64) (string, error) {
 // GenerateKSt1 creates a simplified "KSt 1" form for the given project with
 // layout similar to the official template. The content here is intentionally
 // generic but demonstrates how fields would be positioned in a real form.
-func (g *Generator) GenerateKSt1(projectID int64) (string, error) {
-	ctx := context.Background()
+func (g *Generator) GenerateKSt1(ctx context.Context, projectID int64) (string, error) {
 	p, _ := g.store.GetProject(ctx, projectID)
 	info := g.formInfo()
 	if info.Name == "" && p != nil {
@@ -287,8 +285,7 @@ func (g *Generator) GenerateKSt1(projectID int64) (string, error) {
 // GenerateAnlageGem creates a simplified "Anlage Gem" form. It mirrors the
 // structure of the official form but uses generic placeholder fields.
 
-func (g *Generator) GenerateAnlageGem(projectID int64) (string, error) {
-	ctx := context.Background()
+func (g *Generator) GenerateAnlageGem(ctx context.Context, projectID int64) (string, error) {
 	p, _ := g.store.GetProject(ctx, projectID)
 	info := g.formInfo()
 	if info.Name == "" && p != nil {
@@ -371,8 +368,7 @@ func (g *Generator) GenerateAnlageGem(projectID int64) (string, error) {
 }
 
 // GenerateAnlageGK creates a placeholder "Anlage GK" form for the given project.
-func (g *Generator) GenerateAnlageGK(projectID int64) (string, error) {
-	ctx := context.Background()
+func (g *Generator) GenerateAnlageGK(ctx context.Context, projectID int64) (string, error) {
 	p, _ := g.store.GetProject(ctx, projectID)
 	info := g.formInfo()
 	if info.Name == "" && p != nil {
@@ -437,8 +433,7 @@ func (g *Generator) GenerateAnlageGK(projectID int64) (string, error) {
 }
 
 // GenerateKSt1F creates a placeholder "KSt 1F" form for the given project.
-func (g *Generator) GenerateKSt1F(projectID int64) (string, error) {
-	ctx := context.Background()
+func (g *Generator) GenerateKSt1F(ctx context.Context, projectID int64) (string, error) {
 	p, _ := g.store.GetProject(ctx, projectID)
 	info := g.formInfo()
 	if info.Name == "" && p != nil {
@@ -496,8 +491,7 @@ func (g *Generator) GenerateKSt1F(projectID int64) (string, error) {
 }
 
 // GenerateAnlageSport creates a placeholder "Anlage Sport" form for the given project.
-func (g *Generator) GenerateAnlageSport(projectID int64) (string, error) {
-	ctx := context.Background()
+func (g *Generator) GenerateAnlageSport(ctx context.Context, projectID int64) (string, error) {
 	p, _ := g.store.GetProject(ctx, projectID)
 	info := g.formInfo()
 	if info.Name == "" && p != nil {
@@ -557,16 +551,16 @@ func (g *Generator) GenerateAnlageSport(projectID int64) (string, error) {
 }
 
 // GenerateAllForms creates all available forms for the given project and returns their paths.
-func (g *Generator) GenerateAllForms(projectID int64) ([]string, error) {
+func (g *Generator) GenerateAllForms(ctx context.Context, projectID int64) ([]string, error) {
 	var paths []string
 
-	report, err := g.GenerateReport(projectID)
+	report, err := g.GenerateReport(ctx, projectID)
 	if err != nil {
 		return nil, err
 	}
 	paths = append(paths, report)
 
-	forms := []func(int64) (string, error){
+	forms := []func(context.Context, int64) (string, error){
 		g.GenerateKSt1,
 		g.GenerateAnlageGem,
 		g.GenerateAnlageGK,
@@ -574,7 +568,7 @@ func (g *Generator) GenerateAllForms(projectID int64) ([]string, error) {
 		g.GenerateAnlageSport,
 	}
 	for _, f := range forms {
-		p, err := f(projectID)
+		p, err := f(ctx, projectID)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/pdf/pdf_test.go
+++ b/internal/pdf/pdf_test.go
@@ -53,7 +53,7 @@ func TestGenerateReport(t *testing.T) {
 
 	cfg := config.Config{TaxYear: 2026}
 	g := NewGenerator(dir, store, &cfg)
-	path, err := g.GenerateReport(proj.ID)
+	path, err := g.GenerateReport(ctx, proj.ID)
 	if err != nil {
 		t.Fatalf("GenerateReport failed: %v", err)
 	}
@@ -101,7 +101,7 @@ func TestFormGeneration(t *testing.T) {
 
 	files := []struct {
 		name     string
-		fn       func(int64) (string, error)
+		fn       func(context.Context, int64) (string, error)
 		expected []string
 	}{
 		{"kst1", g.GenerateKSt1, []string{"Einnahmen gesamt", "100.00", "Ausgaben gesamt", "2026"}},
@@ -111,7 +111,7 @@ func TestFormGeneration(t *testing.T) {
 		{"sport", g.GenerateAnlageSport, []string{"Mitgliederzahl", "1", "Einnahmen aus Sportbetrieb"}},
 	}
 	for _, f := range files {
-		path, err := f.fn(proj.ID)
+		path, err := f.fn(ctx, proj.ID)
 		if err != nil {
 			t.Fatalf("%s failed: %v", f.name, err)
 		}
@@ -134,7 +134,7 @@ func TestFormGeneration(t *testing.T) {
 	}
 
 	// test GenerateAllForms
-	paths, err := g.GenerateAllForms(proj.ID)
+	paths, err := g.GenerateAllForms(ctx, proj.ID)
 	if err != nil {
 		t.Fatalf("GenerateAllForms failed: %v", err)
 	}
@@ -181,7 +181,7 @@ func TestGenerateReportCombinations(t *testing.T) {
 			}
 
 			g := NewGenerator(dir, store, &config.Config{})
-			path, err := g.GenerateReport(proj.ID)
+			path, err := g.GenerateReport(ctx, proj.ID)
 			if err != nil {
 				t.Fatalf("GenerateReport failed: %v", err)
 			}


### PR DESCRIPTION
## Summary
- pass `context.Context` into PDF generator methods and use it for store calls
- update tests for the new method signatures

## Testing
- `go test ./cmd/... ./internal/... ./internal/pdf/...`

------
https://chatgpt.com/codex/tasks/task_e_68699f00406483339fab6e3a1e55399d