### PR TITLE
Add runtime log format switching

### DIFF
--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -256,6 +256,13 @@ func (ds *DataService) SetLogLevel(level string) {
 	ds.logger.Info("log level changed", "level", level)
 }
 
+// SetLogFormat updates the log output format (text or json).
+func (ds *DataService) SetLogFormat(format string) {
+	SetLogFormat(format)
+	ds.logger = Logger()
+	ds.logger.Info("log format changed", "format", format)
+}
+
 // RestoreDatabase replaces the current SQLite file with the one at src.
 // The service closes the datastore, copies the file and reopens the connection.
 func (ds *DataService) RestoreDatabase(src string) error {

--- a/internal/service/service_test.go
+++ b/internal/service/service_test.go
@@ -412,6 +412,30 @@ func TestDataService_SetLogLevel(t *testing.T) {
 	}
 }
 
+func TestDataService_SetLogFormat(t *testing.T) {
+	tmpDir := t.TempDir()
+	logPath := filepath.Join(tmpDir, "app.log")
+	logger, closer := NewLogger(logPath, "info", "text")
+	ds, err := NewDataService(":memory:", logger, closer)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ds.Close()
+
+	ds.SetLogFormat("json")
+	if closer != nil {
+		closer.Close()
+	}
+
+	data, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Contains(data, []byte("\"format\"")) && !bytes.Contains(data, []byte("\"level\"")) {
+		t.Fatalf("expected json log, got %s", data)
+	}
+}
+
 func TestDataService_ExportProjectCSV(t *testing.T) {
 	tmpDir := t.TempDir()
 	dbPath := filepath.Join(tmpDir, "db.db")

--- a/internal/ui/src/components/SettingsPanel.jsx
+++ b/internal/ui/src/components/SettingsPanel.jsx
@@ -13,6 +13,7 @@ import {
   ExportDatabase,
   RestoreDatabase,
   SetLogLevel,
+  SetLogFormat,
   ExportProjectCSV,
 } from "../wailsjs/go/service/DataService";
 import { SetTaxYear } from "../wailsjs/go/pdf/Generator";
@@ -60,7 +61,8 @@ export default function SettingsPanel({ projectId }) {
   };
 
   const changeFormat = () => {
-    setMsg(t("settings.applied"));
+    SetLogFormat(format);
+    setFeedback({ type: "success", text: t("settings.applied") });
   };
 
   const applyYear = () => {

--- a/internal/ui/src/wailsjs/go/service/DataService.js
+++ b/internal/ui/src/wailsjs/go/service/DataService.js
@@ -82,6 +82,10 @@ export function SetLogLevel(arg1) {
   return window.go.service.DataService.SetLogLevel(arg1);
 }
 
+export function SetLogFormat(arg1) {
+  return window.go.service.DataService.SetLogFormat(arg1);
+}
+
 export function ExportProjectCSV(arg1, arg2) {
   return window.go.service.DataService.ExportProjectCSV(arg1, arg2);
 }


### PR DESCRIPTION
## Summary
- allow switching logger format while application is running
- expose `SetLogFormat` on DataService
- send log format from SettingsPanel
- cover new behaviour with unit tests

## Testing
- `go vet ./cmd/... ./internal/... ./internal/pdf/...`
- `go test ./cmd/... ./internal/... ./internal/pdf/...`
- `npm run lint --prefix internal/ui`
- `npm test --prefix internal/ui`


------
https://chatgpt.com/codex/tasks/task_e_68699efcb588833397127f5cab04e662