### PR TITLE
Fix settings feedback and test

### DIFF
--- a/internal/ui/src/components/SettingsPanel.jsx
+++ b/internal/ui/src/components/SettingsPanel.jsx
@@ -60,7 +60,7 @@ export default function SettingsPanel({ projectId }) {
   };
 
   const changeFormat = () => {
-    setMsg(t("settings.applied"));
+    setFeedback({ type: "success", text: t("settings.applied") });
   };
 
   const applyYear = () => {

--- a/internal/ui/src/components/SettingsPanel.test.jsx
+++ b/internal/ui/src/components/SettingsPanel.test.jsx
@@ -1,0 +1,27 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { vi, beforeEach } from 'vitest';
+import SettingsPanel from './SettingsPanel';
+import '../i18n';
+
+vi.mock('../wailsjs/go/service/DataService', () => ({
+  ExportDatabase: vi.fn(),
+  RestoreDatabase: vi.fn(),
+  SetLogLevel: vi.fn(),
+  ExportProjectCSV: vi.fn(),
+}), { virtual: true });
+
+vi.mock('../wailsjs/go/pdf/Generator', () => ({
+  SetTaxYear: vi.fn(),
+}), { virtual: true });
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+test('shows success message when log format applied', async () => {
+  render(<SettingsPanel projectId={1} />);
+  const applyButtons = screen.getAllByRole('button', { name: /Anwenden/i });
+  fireEvent.click(applyButtons[1]);
+  expect(await screen.findByText('settings.applied')).toBeInTheDocument();
+});


### PR DESCRIPTION
## Summary
- show success feedback when changing log format
- cover log format feedback with a new unit test

## Testing
- `npm test --prefix internal/ui`
- `go test ./cmd/... ./internal/... ./internal/pdf/...`


------
https://chatgpt.com/codex/tasks/task_e_68699efc64188333a423c97f885c2a63