### PR TITLE
Implement detailed PDF report generation

### DIFF
--- a/internal/ui/e2e/mockPDFGenerator.js
+++ b/internal/ui/e2e/mockPDFGenerator.js
@@ -11,6 +11,7 @@
   }
   [
     'GenerateReport',
+    'GenerateDetailedReport',
     'GenerateKSt1',
     'GenerateAnlageGem',
     'GenerateAnlageGK',

--- a/internal/ui/src/components/FormsPanel.jsx
+++ b/internal/ui/src/components/FormsPanel.jsx
@@ -11,6 +11,7 @@ import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import {
   GenerateAllForms,
+  GenerateDetailedReport,
   GenerateAnlageGem,
   GenerateAnlageGK,
   GenerateAnlageSport,
@@ -42,6 +43,19 @@ export default function FormsPanel({ projectId }) {
           >
             {t('forms.generate_all')}
           </Button>
+        </Grid>
+        <Grid item xs={12} sm={6}>
+          <Card>
+            <CardContent>
+              <Typography gutterBottom>{t('form.detailedReport')}</Typography>
+              <Button
+                variant="outlined"
+                onClick={() => handleGenerate(GenerateDetailedReport)}
+              >
+                {t('form.generate')}
+              </Button>
+            </CardContent>
+          </Card>
         </Grid>
         <Grid item xs={12} sm={6}>
           <Card>

--- a/internal/ui/src/components/SettingsPanel.test.jsx
+++ b/internal/ui/src/components/SettingsPanel.test.jsx
@@ -8,6 +8,7 @@ vi.mock('../wailsjs/go/service/DataService', () => ({
   ExportDatabase: vi.fn(),
   RestoreDatabase: vi.fn(),
   SetLogLevel: vi.fn(),
+  SetLogFormat: vi.fn(),
   ExportProjectCSV: vi.fn(),
 }), { virtual: true });
 

--- a/internal/ui/src/locales/de.json
+++ b/internal/ui/src/locales/de.json
@@ -77,7 +77,8 @@
     "anlageGem": "Anlage Gem",
     "anlageGK": "Anlage GK",
     "kst1f": "KSt 1F",
-    "anlageSport": "Anlage Sport"
+    "anlageSport": "Anlage Sport",
+    "detailedReport": "Detaillierter Bericht"
   },
   "tax": {
     "calculate": "Steuern berechnen",

--- a/internal/ui/src/locales/en.json
+++ b/internal/ui/src/locales/en.json
@@ -77,7 +77,8 @@
     "anlageGem": "Anlage Gem",
     "anlageGK": "Anlage GK",
     "kst1f": "KSt 1F",
-    "anlageSport": "Anlage Sport"
+    "anlageSport": "Anlage Sport",
+    "detailedReport": "Detailed Report"
   },
   "tax": {
     "calculate": "Calculate Taxes",

--- a/internal/ui/src/wailsjs/go/pdf/Generator.js
+++ b/internal/ui/src/wailsjs/go/pdf/Generator.js
@@ -2,6 +2,10 @@ export function GenerateReport(projectID) {
   return window.go.pdf.Generator.GenerateReport(projectID);
 }
 
+export function GenerateDetailedReport(projectID) {
+  return window.go.pdf.Generator.GenerateDetailedReport(projectID);
+}
+
 export function GenerateKSt1(projectID) {
   return window.go.pdf.Generator.GenerateKSt1(projectID);
 }


### PR DESCRIPTION
## Summary
- add `GenerateDetailedReport` in pdf generator
- export new method to Wails bindings and update mock
- show new button in `FormsPanel` for the detailed report
- localize new text in German and English
- adjust SettingsPanel tests for complete mocks
- test detailed PDF generation

## Testing
- `go vet ./cmd/... ./internal/... ./internal/pdf/...`
- `go test ./cmd/... ./internal/... ./internal/pdf/...`
- `npm run lint --prefix internal/ui`
- `npm test --prefix internal/ui`


------
https://chatgpt.com/codex/tasks/task_e_6869a993e7ec833391ad25dae0b3f90f