### PR TITLE
Add cloud sync placeholder

### DIFF
--- a/docs/cloud-sync.md
+++ b/docs/cloud-sync.md
@@ -1,0 +1,7 @@
+# Cloud Sync (Preview)
+
+Dieses Projekt wird zukünftig eine optionale Synchronisierung der SQLite-Datenbank über einen Cloud-Service unterstützen. 
+Aktuell existiert lediglich eine lokale Platzhalter-Implementierung, die Dateien in ein Unterverzeichnis `syncdata/` kopiert.
+
+Zum Testen kann einfach `SyncUpload` bzw. `SyncDownload` über die Anwendung aufgerufen werden.
+Die eigentliche Integration einer REST-API oder eines anderen Dienstes folgt später.

--- a/internal/sync/sync.go
+++ b/internal/sync/sync.go
@@ -1,0 +1,57 @@
+package sync
+
+import (
+	"context"
+	"io"
+	"os"
+	"path/filepath"
+)
+
+// Client defines upload and download operations for the database.
+type Client interface {
+	Upload(ctx context.Context, src string) error
+	Download(ctx context.Context, dest string) error
+}
+
+// LocalClient is a placeholder implementation storing files locally.
+type LocalClient struct{ BaseDir string }
+
+// NewLocalClient returns a LocalClient using the given directory.
+func NewLocalClient(dir string) *LocalClient {
+	if dir == "" {
+		dir = "syncdata"
+	}
+	return &LocalClient{BaseDir: dir}
+}
+
+func copyFile(src, dest string) error {
+	in, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer in.Close()
+
+	if err := os.MkdirAll(filepath.Dir(dest), 0o755); err != nil {
+		return err
+	}
+	out, err := os.Create(dest)
+	if err != nil {
+		return err
+	}
+	defer out.Close()
+
+	_, err = io.Copy(out, in)
+	return err
+}
+
+// Upload copies src into the client's base directory.
+func (c *LocalClient) Upload(ctx context.Context, src string) error {
+	dest := filepath.Join(c.BaseDir, filepath.Base(src))
+	return copyFile(src, dest)
+}
+
+// Download copies the stored file into dest.
+func (c *LocalClient) Download(ctx context.Context, dest string) error {
+	src := filepath.Join(c.BaseDir, filepath.Base(dest))
+	return copyFile(src, dest)
+}


### PR DESCRIPTION
## Summary
- add new `internal/sync` package with basic upload/download interfaces
- extend `DataService` with `SyncUpload` and `SyncDownload` methods using a local client
- document preview of cloud sync in `docs/cloud-sync.md`

## Testing
- `go vet ./cmd/... ./internal/... ./internal/pdf/...`
- `go test ./cmd/... ./internal/... ./internal/pdf/...`


------
https://chatgpt.com/codex/tasks/task_e_6869a995ca1c8333b52d7e98ecb0a630