### PR TITLE
Improve CI workflow and build scripts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,34 @@ on:
   pull_request:
 
 jobs:
-  build:
+  frontend:
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v3
+      - name: Setup Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: '20'
+      - name: Install frontend deps
+        run: npm ci
+        working-directory: internal/ui
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps
+        working-directory: internal/ui
+      - name: Lint frontend
+        run: npm run lint
+        working-directory: internal/ui
+      - name: Run frontend tests
+        run: npm test
+        working-directory: internal/ui
+      - name: Run e2e tests
+        run: npm run test:e2e
+        working-directory: internal/ui
+
+  go:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
@@ -17,42 +44,14 @@ jobs:
         run: |
           gofmt -w $(git ls-files '*.go')
           git diff --exit-code
-
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
           go-version: '1.22'
-
       - name: Sync Go workspace
         run: go work sync
-
-      - name: Setup Node
-        uses: actions/setup-node@v3
-        with:
-          node-version: '20'
-
-      - name: Install frontend deps
-        run: npm ci
-        working-directory: internal/ui
-
-      - name: Install Playwright browsers
-        run: npx playwright install --with-deps
-        working-directory: internal/ui
-
-      - name: Lint frontend
-        run: npm run lint
-        working-directory: internal/ui
-
-      - name: Run frontend tests
-        run: npm test
-        working-directory: internal/ui
-
-      - name: Run e2e tests
-        run: npm run test:e2e
-        working-directory: internal/ui
-
       - name: Go vet
         run: go vet ./cmd/... ./internal/... ./internal/pdf/...
-
       - name: Go tests
         run: go test ./cmd/... ./internal/... ./internal/pdf/...
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,11 @@
 FROM golang:1.22-bullseye AS build
 
-# Install Node.js and npm
-RUN apt-get update && apt-get install -y nodejs npm && rm -rf /var/lib/apt/lists/*
+# Install Node.js from official binaries
+ARG NODE_VERSION=20.19.3
+RUN curl -fsSL https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-x64.tar.xz \
+    | tar -xJf - -C /usr/local --strip-components=1 \
+    && ln -s /usr/local/bin/node /usr/local/bin/nodejs \
+    && npm install -g npm@latest
 
 WORKDIR /app
 

--- a/scripts/package.sh
+++ b/scripts/package.sh
@@ -12,7 +12,11 @@ OUTPUT_DIR="$ROOT_DIR/build/bin/$VERSION"
 rm -rf "$OUTPUT_DIR"
 mkdir -p "$OUTPUT_DIR"
 
-PLATFORMS=("darwin/universal" "windows/amd64" "linux/amd64" "linux/arm64")
+if [[ -z "${PLATFORMS:-}" ]]; then
+    PLATFORMS=("darwin/universal" "windows/amd64" "linux/amd64" "linux/arm64")
+else
+    read -ra PLATFORMS <<< "$PLATFORMS"
+fi
 
 for PLATFORM in "${PLATFORMS[@]}"; do
     echo "==> Building for $PLATFORM"


### PR DESCRIPTION
## Summary
- run Go and frontend tests in parallel
- optimize Dockerfile Node install
- allow custom platform list in `scripts/package.sh`

## Testing
- `go test ./cmd/... ./internal/... ./internal/pdf/...`
- `npm test --prefix internal/ui` *(fails: No `SetLogFormat` export defined)*

------
https://chatgpt.com/codex/tasks/task_e_6869a9960e5c8333a34b1fedd2d61b78