### PR TITLE
Implement member update feature across app

### DIFF
--- a/internal/data/store_test.go
+++ b/internal/data/store_test.go
@@ -159,11 +159,12 @@ func TestMemberCRUD(t *testing.T) {
 	}
 
 	m.Name = "Alice Smith"
+	m.JoinDate = "2024-02-01"
 	if err := s.UpdateMember(ctx, m); err != nil {
 		t.Fatal(err)
 	}
 	got, _ = s.GetMember(ctx, m.ID)
-	if got.Name != "Alice Smith" {
+	if got.Name != "Alice Smith" || got.JoinDate != "2024-02-01" {
 		t.Fatalf("update failed")
 	}
 

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -196,6 +196,16 @@ func (ds *DataService) AddMember(ctx context.Context, name, email, joinDate stri
 	return m, nil
 }
 
+// UpdateMember updates an existing member.
+func (ds *DataService) UpdateMember(ctx context.Context, id int64, name, email, joinDate string) error {
+	m := &data.Member{ID: id, Name: name, Email: email, JoinDate: joinDate}
+	if err := ds.store.UpdateMember(ctx, m); err != nil {
+		return fmt.Errorf("update member: %w", err)
+	}
+	ds.logger.Info("updated member", "id", id)
+	return nil
+}
+
 // ListMembers returns all members sorted by name.
 func (ds *DataService) ListMembers(ctx context.Context) ([]data.Member, error) {
 	members, err := ds.store.ListMembers(ctx)

--- a/internal/service/service_test.go
+++ b/internal/service/service_test.go
@@ -211,6 +211,39 @@ func TestDataService_MemberOperations(t *testing.T) {
 	}
 }
 
+func TestDataService_UpdateDeleteMember(t *testing.T) {
+	ds, err := NewDataService(":memory:", slog.New(slog.NewTextHandler(io.Discard, nil)), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ds.Close()
+
+	ctx := context.Background()
+
+	m, err := ds.AddMember(ctx, "Bob", "bob@example.com", "2024-01-10")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := ds.UpdateMember(ctx, m.ID, "Bobby", "bob@example.com", "2024-02-01"); err != nil {
+		t.Fatalf("UpdateMember failed: %v", err)
+	}
+
+	members, _ := ds.ListMembers(ctx)
+	if len(members) != 1 || members[0].Name != "Bobby" || members[0].JoinDate != "2024-02-01" {
+		t.Fatalf("update failed: %+v", members)
+	}
+
+	if err := ds.DeleteMember(ctx, m.ID); err != nil {
+		t.Fatalf("DeleteMember failed: %v", err)
+	}
+
+	members, _ = ds.ListMembers(ctx)
+	if len(members) != 0 {
+		t.Fatalf("expected empty list, got %+v", members)
+	}
+}
+
 func TestDataService_AddIncome_LogOutput(t *testing.T) {
 	ds, err := NewDataService(":memory:", slog.New(slog.NewTextHandler(io.Discard, nil)), nil)
 	if err != nil {

--- a/internal/ui/src/App.jsx
+++ b/internal/ui/src/App.jsx
@@ -3,7 +3,7 @@ import { ThemeProvider, createTheme } from "@mui/material/styles";
 import { CssBaseline, Container, FormControlLabel, Switch, AppBar, Toolbar, Typography, Tabs, Tab, Paper, Select, MenuItem, Snackbar, Alert } from "@mui/material";
 import { useTranslation } from "react-i18next";
 import "./i18n";
-import { ListExpenses, ListIncomes, AddIncome, UpdateIncome, DeleteIncome, AddExpense, UpdateExpense, DeleteExpense, AddMember, ListMembers, DeleteMember } from "./wailsjs/go/service/DataService";
+import { ListExpenses, ListIncomes, AddIncome, UpdateIncome, DeleteIncome, AddExpense, UpdateExpense, DeleteExpense, AddMember, UpdateMember, ListMembers, DeleteMember } from "./wailsjs/go/service/DataService";
 import ProjectPanel from "./components/ProjectPanel";
 import IncomeForm from "./components/IncomeForm";
 import IncomeTable from "./components/IncomeTable";
@@ -19,6 +19,7 @@ export default function App() {
   const [incomes, setIncomes] = useState([]);
   const [expenses, setExpenses] = useState([]);
   const [members, setMembers] = useState([]);
+  const [editMember, setEditMember] = useState(null);
   const [editIncome, setEditIncome] = useState(null);
   const [editExpense, setEditExpense] = useState(null);
   const [darkMode, setDarkMode] = useState(false);
@@ -100,7 +101,12 @@ export default function App() {
 
   const submitMember = async (name, email, joinDate, setError) => {
     try {
-      await AddMember(name, email, joinDate);
+      if (editMember) {
+        await UpdateMember(editMember.id, name, email, joinDate);
+        setEditMember(null);
+      } else {
+        await AddMember(name, email, joinDate);
+      }
       setError("");
       fetchMembers();
     } catch (err) {
@@ -151,11 +157,12 @@ export default function App() {
               <Typography variant="h6" component="h2" gutterBottom>
                 {t('member.new')}
               </Typography>
-              <MemberForm onSubmit={submitMember} />
+              <MemberForm onSubmit={submitMember} editItem={editMember} />
             </Paper>
             <Paper>
               <MemberTable
                 members={members}
+                onEdit={(m) => setEditMember(m)}
                 onDelete={async (id) => {
                   await DeleteMember(id);
                   fetchMembers();

--- a/internal/ui/src/components/MemberForm.jsx
+++ b/internal/ui/src/components/MemberForm.jsx
@@ -2,11 +2,11 @@ import { useState } from "react";
 import { Box, TextField, Button, Snackbar, Alert } from "@mui/material";
 import { useTranslation } from "react-i18next";
 
-export default function MemberForm({ onSubmit }) {
+export default function MemberForm({ onSubmit, editItem }) {
   const { t } = useTranslation();
-  const [name, setName] = useState("");
-  const [email, setEmail] = useState("");
-  const [joinDate, setJoinDate] = useState("2024-01-01");
+  const [name, setName] = useState(editItem ? editItem.name : "");
+  const [email, setEmail] = useState(editItem ? editItem.email : "");
+  const [joinDate, setJoinDate] = useState(editItem ? editItem.joinDate : "2024-01-01");
   const [error, setError] = useState("");
   const emailPattern = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
   const datePattern = /^\d{4}-\d{2}-\d{2}$/;
@@ -26,8 +26,10 @@ export default function MemberForm({ onSubmit }) {
       return;
     }
     await onSubmit(name, email, joinDate, setError);
-    setName("");
-    setEmail("");
+    if (!editItem) {
+      setName("");
+      setEmail("");
+    }
   };
 
   return (

--- a/internal/ui/src/components/MemberForm.test.jsx
+++ b/internal/ui/src/components/MemberForm.test.jsx
@@ -37,3 +37,12 @@ test('shows submit error', async () => {
   fireEvent.click(screen.getByRole('button', { name: /Hinzufügen/i }));
   expect(await screen.findByText('fail')).toBeInTheDocument();
 });
+
+test('prefills data when editing', () => {
+  const item = { id: 1, name: 'Eve', email: 'eve@example.com', joinDate: '2024-01-05' };
+  render(<MemberForm onSubmit={onSubmit} editItem={item} />);
+  expect(screen.getByDisplayValue('Eve')).toBeInTheDocument();
+  expect(screen.getByDisplayValue('eve@example.com')).toBeInTheDocument();
+  fireEvent.click(screen.getByRole('button', { name: /Hinzufügen/i }));
+  expect(onSubmit).toHaveBeenCalled();
+});

--- a/internal/ui/src/components/MemberTable.jsx
+++ b/internal/ui/src/components/MemberTable.jsx
@@ -1,7 +1,7 @@
 import { Table, TableHead, TableBody, TableRow, TableCell, Button } from "@mui/material";
 import { useTranslation } from "react-i18next";
 
-export default function MemberTable({ members, onDelete }) {
+export default function MemberTable({ members, onEdit, onDelete }) {
   const { t } = useTranslation();
   return (
     <Table>
@@ -21,6 +21,11 @@ export default function MemberTable({ members, onDelete }) {
               <TableCell>{m.email}</TableCell>
               <TableCell>{m.joinDate}</TableCell>
               <TableCell>
+                {onEdit && (
+                  <Button size="small" onClick={() => onEdit(m)}>
+                    {t('edit')}
+                  </Button>
+                )}
                 <Button size="small" color="error" onClick={() => onDelete(m.id)}>
                   {t('delete')}
                 </Button>

--- a/internal/ui/src/components/MemberTable.test.jsx
+++ b/internal/ui/src/components/MemberTable.test.jsx
@@ -4,6 +4,7 @@ import MemberTable from './MemberTable';
 import '../i18n';
 
 const onDelete = vi.fn();
+const onEdit = vi.fn();
 
 beforeEach(() => {
   vi.clearAllMocks();
@@ -19,4 +20,11 @@ test('calls delete callback', () => {
   render(<MemberTable members={members} onDelete={onDelete} />);
   fireEvent.click(screen.getByRole('button', { name: /Löschen/i }));
   expect(onDelete).toHaveBeenCalledWith(1);
+});
+
+test('calls edit callback', () => {
+  const members = [{ id: 2, name: 'Bob', email: 'b@example.com', joinDate: '2024-01-01' }];
+  render(<MemberTable members={members} onDelete={onDelete} onEdit={onEdit} />);
+  fireEvent.click(screen.getByRole('button', { name: /Bearbeiten/i }));
+  expect(onEdit).toHaveBeenCalledWith(members[0]);
 });

--- a/internal/ui/src/components/SettingsPanel.test.jsx
+++ b/internal/ui/src/components/SettingsPanel.test.jsx
@@ -8,6 +8,7 @@ vi.mock('../wailsjs/go/service/DataService', () => ({
   ExportDatabase: vi.fn(),
   RestoreDatabase: vi.fn(),
   SetLogLevel: vi.fn(),
+  SetLogFormat: vi.fn(),
   ExportProjectCSV: vi.fn(),
 }), { virtual: true });
 

--- a/internal/ui/src/wailsjs/go/service/DataService.js
+++ b/internal/ui/src/wailsjs/go/service/DataService.js
@@ -62,6 +62,10 @@ export function AddMember(arg1, arg2, arg3) {
   return window.go.service.DataService.AddMember(arg1, arg2, arg3);
 }
 
+export function UpdateMember(arg1, arg2, arg3, arg4) {
+  return window.go.service.DataService.UpdateMember(arg1, arg2, arg3, arg4);
+}
+
 export function ListMembers() {
   return window.go.service.DataService.ListMembers();
 }


### PR DESCRIPTION
## Summary
- allow updating members via new `UpdateMember` in backend service
- support editing of members in the React frontend
- expose `UpdateMember` in generated JS bindings
- extend member CRUD tests in datastore and service
- update UI tests to cover editing
- fix SettingsPanel test mocks

## Testing
- `go test ./internal/...`
- `npm test --prefix internal/ui`

------
https://chatgpt.com/codex/tasks/task_e_6869a992e0cc8333a8afea3e015f8520