### PR TITLE
Add PDF template support

### DIFF
--- a/docs/Todo-fuer-User.md
+++ b/docs/Todo-fuer-User.md
@@ -8,3 +8,7 @@ Die Repository-Richtlinien sehen vor, dass große oder binäre Dateien (z. B. Be
 4. Große Dateien sollten nach Möglichkeit komprimiert (ZIP) und mit einer kurzen Erläuterung versehen werden.
 
 So bleiben die Versionskontrolle und der Repository-Umfang schlank, während trotzdem alle notwendigen Daten verfügbar sind.
+
+## Offizielle Formulare einbinden
+
+Im Verzeichnis `internal/pdf/templates` befinden sich nur Platzhalterdateien. Um die amtlichen PDF-Formulare zu verwenden, kopieren Sie die Originale mit dem gleichen Dateinamen (z. B. `kst1.pdf`) in dieses Verzeichnis. Beim Erzeugen der Formulare greift der Generator automatisch auf diese Vorlagen zurück.

--- a/internal/pdf/go.mod
+++ b/internal/pdf/go.mod
@@ -3,3 +3,8 @@ module baristeuer/internal/pdf
 go 1.22
 
 require github.com/jung-kurt/gofpdf v1.16.2
+
+require (
+	github.com/phpdave11/gofpdi v1.0.7 // indirect
+	github.com/pkg/errors v0.8.1 // indirect
+)

--- a/internal/pdf/go.sum
+++ b/internal/pdf/go.sum
@@ -3,7 +3,9 @@ github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/jung-kurt/gofpdf v1.0.0/go.mod h1:7Id9E/uU8ce6rXgefFLlgrJj/GYY22cpxn+r32jIOes=
 github.com/jung-kurt/gofpdf v1.16.2 h1:jgbatWHfRlPYiK85qgevsZTHviWXKwB1TTiKdz5PtRc=
 github.com/jung-kurt/gofpdf v1.16.2/go.mod h1:1hl7y57EsiPAkLbOwzpzqgx1A30nQCk/YmFV8S2vmK0=
+github.com/phpdave11/gofpdi v1.0.7 h1:k2oy4yhkQopCK+qW8KjCla0iU2RpDow+QUDmH9DDt44=
 github.com/phpdave11/gofpdi v1.0.7/go.mod h1:vBmVV0Do6hSBHC8uKUQ71JGW+ZGQq74llk/7bXwjDoI=
+github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/ruudk/golang-pdf417 v0.0.0-20181029194003-1af4ab5afa58/go.mod h1:6lfFZQK844Gfx8o5WFuvpxWRwnSoipWe/p622j1v06w=

--- a/internal/pdf/pdf.go
+++ b/internal/pdf/pdf.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/jung-kurt/gofpdf"
+	gofpdi "github.com/jung-kurt/gofpdf/contrib/gofpdi"
 
 	"baristeuer/internal/config"
 	"baristeuer/internal/data"
@@ -18,6 +19,24 @@ import (
 
 // Error returned when a PDF file cannot be created or written.
 var ErrWritePDF = errors.New("write PDF")
+
+const templatesDir = "internal/pdf/templates"
+
+func addTemplate(pdf *gofpdf.Fpdf, name string) {
+	pdfPath := filepath.Join(templatesDir, name+".pdf")
+	if _, err := os.Stat(pdfPath); err == nil {
+		imp := gofpdi.NewImporter()
+		tpl := imp.ImportPage(pdf, pdfPath, 1, "/MediaBox")
+		imp.UseImportedTemplate(pdf, tpl, 0, 0, 210, 297)
+		return
+	}
+	metaPath := filepath.Join(templatesDir, name+".txt")
+	if b, err := os.ReadFile(metaPath); err == nil {
+		pdf.SetFont("Arial", "", 8)
+		pdf.MultiCell(0, 4, string(b), "", "L", false)
+		pdf.Ln(4)
+	}
+}
 
 // Generator handles PDF creation.
 type Generator struct {
@@ -338,6 +357,7 @@ func (g *Generator) GenerateKSt1(ctx context.Context, projectID int64) (string, 
 	pdf := gofpdf.New("P", "mm", "A4", "")
 	pdf.SetCompression(false)
 	pdf.AddPage()
+	addTemplate(pdf, "kst1")
 	pdf.SetFont("Arial", "B", 14)
 	pdf.CellFormat(0, 10, "KSt 1 - K\xC3\xB6rperschaftsteuererkl\xC3\xA4rung", "", 1, "C", false, 0, "")
 	pdf.Ln(4)
@@ -431,6 +451,7 @@ func (g *Generator) GenerateAnlageGem(ctx context.Context, projectID int64) (str
 	pdf := gofpdf.New("P", "mm", "A4", "")
 	pdf.SetCompression(false)
 	pdf.AddPage()
+	addTemplate(pdf, "anlage_gem")
 	pdf.SetFont("Arial", "B", 14)
 	pdf.CellFormat(0, 10, title, "", 1, "C", false, 0, "")
 	pdf.Ln(4)
@@ -504,6 +525,7 @@ func (g *Generator) GenerateAnlageGK(ctx context.Context, projectID int64) (stri
 	pdf := gofpdf.New("P", "mm", "A4", "")
 	pdf.SetCompression(false)
 	pdf.AddPage()
+	addTemplate(pdf, "anlage_gk")
 	pdf.SetFont("Arial", "B", 14)
 	pdf.CellFormat(0, 10, title, "", 1, "C", false, 0, "")
 	pdf.Ln(4)
@@ -566,6 +588,7 @@ func (g *Generator) GenerateKSt1F(ctx context.Context, projectID int64) (string,
 	pdf := gofpdf.New("P", "mm", "A4", "")
 	pdf.SetCompression(false)
 	pdf.AddPage()
+	addTemplate(pdf, "kst1f")
 	pdf.SetFont("Arial", "B", 14)
 	pdf.CellFormat(0, 10, title, "", 1, "C", false, 0, "")
 	pdf.Ln(4)
@@ -628,6 +651,7 @@ func (g *Generator) GenerateAnlageSport(ctx context.Context, projectID int64) (s
 	pdf := gofpdf.New("P", "mm", "A4", "")
 	pdf.SetCompression(false)
 	pdf.AddPage()
+	addTemplate(pdf, "anlage_sport")
 	pdf.SetFont("Arial", "B", 14)
 	pdf.CellFormat(0, 10, title, "", 1, "C", false, 0, "")
 	pdf.Ln(4)

--- a/internal/pdf/templates/README.md
+++ b/internal/pdf/templates/README.md
@@ -1,0 +1,3 @@
+Diese Dateien sind Platzhalter fuer die amtlichen Formularvorlagen.
+Um die Originale zu verwenden, lege die entsprechenden PDF-Dateien hier ab,
+benannt wie die .txt-Dateien aber mit der Endung .pdf.

--- a/internal/pdf/templates/anlage_gem.txt
+++ b/internal/pdf/templates/anlage_gem.txt
@@ -1,0 +1,1 @@
+Placeholder for official Anlage Gem form

--- a/internal/pdf/templates/anlage_gk.txt
+++ b/internal/pdf/templates/anlage_gk.txt
@@ -1,0 +1,1 @@
+Placeholder for official Anlage GK form

--- a/internal/pdf/templates/anlage_sport.txt
+++ b/internal/pdf/templates/anlage_sport.txt
@@ -1,0 +1,1 @@
+Placeholder for official Anlage Sport form

--- a/internal/pdf/templates/kst1.txt
+++ b/internal/pdf/templates/kst1.txt
@@ -1,0 +1,1 @@
+Placeholder for official KSt 1 form

--- a/internal/pdf/templates/kst1f.txt
+++ b/internal/pdf/templates/kst1f.txt
@@ -1,0 +1,1 @@
+Placeholder for official KSt 1F form


### PR DESCRIPTION
## Summary
- add placeholder template files for official forms
- embed templates in PDF generator
- document how to include real forms

## Testing
- `go test ./cmd/... ./internal/... ./internal/pdf/...`

------
https://chatgpt.com/codex/tasks/task_e_6869b3c764208333a5305b3b051118e7