### PR TITLE
Add plugin example and loader improvements

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -98,8 +98,19 @@ func main() {
 	datasvc := service.NewDataServiceFromStore(store, logger, logCloser)
 	defer datasvc.Close()
 
-	// Load optional runtime plugins from ./plugins if available.
-	loadPlugins("plugins", datasvc)
+	// Load optional runtime plugins from a "plugins" directory located next
+	// to the executable. The BARISTEUER_PLUGINS environment variable can
+	// override the directory.
+	pluginDir := os.Getenv("BARISTEUER_PLUGINS")
+	if pluginDir == "" {
+		exe, err := os.Executable()
+		if err == nil {
+			pluginDir = filepath.Join(filepath.Dir(exe), "plugins")
+		} else {
+			pluginDir = "plugins"
+		}
+	}
+	loadPlugins(pluginDir, datasvc)
 
 	if *exportPath != "" {
 		if err := datasvc.ExportDatabase(*exportPath); err != nil {

--- a/cmd/plugin_e2e_test.go
+++ b/cmd/plugin_e2e_test.go
@@ -1,0 +1,57 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"baristeuer/internal/service"
+)
+
+func TestExamplePlugin(t *testing.T) {
+	tmpDir := t.TempDir()
+	soPath := filepath.Join(tmpDir, "example.so")
+
+	build := exec.Command("go", "build", "-buildmode=plugin", "-o", soPath, filepath.Join("..", "plugins", "example"))
+	if out, err := build.CombinedOutput(); err != nil {
+		t.Fatalf("build plugin: %v\n%s", err, out)
+	}
+
+	ds, err := service.NewDataService(":memory:", slog.New(slog.NewTextHandler(io.Discard, nil)), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ds.Close()
+
+	ctx := context.Background()
+	proj, err := ds.CreateProject(ctx, "Demo")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := ds.AddIncome(ctx, proj.ID, "donation", 10); err != nil {
+		t.Fatal(err)
+	}
+
+	exportPath := filepath.Join(tmpDir, "out.json")
+	os.Setenv("EXAMPLE_EXPORT_FILE", exportPath)
+	defer os.Unsetenv("EXAMPLE_EXPORT_FILE")
+
+	loadPlugins(tmpDir, ds)
+
+	data, err := os.ReadFile(exportPath)
+	if err != nil {
+		t.Fatalf("read export: %v", err)
+	}
+	var arr []any
+	if err := json.Unmarshal(data, &arr); err != nil {
+		t.Fatalf("invalid json: %v", err)
+	}
+	if len(arr) == 0 {
+		t.Fatal("export empty")
+	}
+}

--- a/docs/DOCUMENTATION.md
+++ b/docs/DOCUMENTATION.md
@@ -133,6 +133,9 @@ type Plugin interface {
 register additional functionality. If the `plugins/` directory does not exist,
 the application starts normally without loading any extensions.
 
+See [Plugin Development Guide](plugin-development.md) for instructions on
+writing and building your own plugins.
+
 ## Cross-Platform Compatibility
 
 Die Anwendung wurde erfolgreich unter **macOS** und **Windows** getestet. Alle Funktionen stehen auf beiden Plattformen ohne Einschränkungen zur Verfügung.

--- a/docs/plugin-development.md
+++ b/docs/plugin-development.md
@@ -1,0 +1,45 @@
+# Plugin Development Guide
+
+Baristeuer supports optional runtime plugins written in Go. Plugins are built as
+shared objects and loaded from the `plugins/` directory next to the executable on
+startup.
+
+## Writing a Plugin
+
+A plugin must implement the `plugins.Plugin` interface located in
+`internal/plugins`:
+
+```go
+package plugins
+
+type Plugin interface {
+    Init(*service.DataService) error
+}
+```
+
+Create a new module in `plugins/<name>` with a `New` function returning your
+implementation. The exported `Init` method receives a `DataService` instance and
+can register additional functionality or perform tasks during start up.
+
+Example structure:
+
+```text
+plugins/example/
+├─ go.mod
+├─ example.go
+```
+
+Build the plugin using the Go compiler with `-buildmode=plugin`:
+
+```bash
+go build -buildmode=plugin -o plugins/example/example.so ./plugins/example
+```
+
+After placing the compiled `.so` file in the `plugins/` directory, Baristeuer
+loads it automatically on the next start.
+
+## Example Plugin
+
+The repository contains a simple exporter plugin in `plugins/example` which
+writes all projects, incomes and expenses to a JSON file. The output path can be
+configured via the `EXAMPLE_EXPORT_FILE` environment variable.

--- a/go.work
+++ b/go.work
@@ -4,4 +4,5 @@ use (
 	./cmd
 	./internal
 	./internal/pdf
+	./plugins/example
 )

--- a/plugins/example/example.go
+++ b/plugins/example/example.go
@@ -1,0 +1,56 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"baristeuer/internal/data"
+	"baristeuer/internal/plugins"
+	"baristeuer/internal/service"
+)
+
+type exporter struct{}
+
+func New() plugins.Plugin { return &exporter{} }
+
+func (e *exporter) Init(ds *service.DataService) error {
+	ctx := context.Background()
+	projects, err := ds.ListProjects()
+	if err != nil {
+		return fmt.Errorf("list projects: %w", err)
+	}
+	type item struct {
+		Project  data.Project   `json:"project"`
+		Incomes  []data.Income  `json:"incomes"`
+		Expenses []data.Expense `json:"expenses"`
+	}
+	var all []item
+	for _, p := range projects {
+		inc, err := ds.ListIncomes(ctx, p.ID)
+		if err != nil {
+			return fmt.Errorf("list incomes: %w", err)
+		}
+		exp, err := ds.ListExpenses(ctx, p.ID)
+		if err != nil {
+			return fmt.Errorf("list expenses: %w", err)
+		}
+		all = append(all, item{Project: p, Incomes: inc, Expenses: exp})
+	}
+	out := os.Getenv("EXAMPLE_EXPORT_FILE")
+	if out == "" {
+		out = "example_export.json"
+	}
+	f, err := os.Create(out)
+	if err != nil {
+		return fmt.Errorf("create export: %w", err)
+	}
+	defer f.Close()
+	enc := json.NewEncoder(f)
+	enc.SetIndent("", "  ")
+	if err := enc.Encode(all); err != nil {
+		return fmt.Errorf("encode export: %w", err)
+	}
+	return nil
+}

--- a/plugins/example/go.mod
+++ b/plugins/example/go.mod
@@ -1,0 +1,3 @@
+module baristeuer/plugins/example
+
+go 1.22


### PR DESCRIPTION
## Summary
- load plugins relative to executable or via BARISTEUER_PLUGINS
- provide example exporter plugin in `plugins/example`
- document plugin development and link from main docs
- add e2e test building and running the example plugin

## Testing
- `make vet`
- `make go-test`

------
https://chatgpt.com/codex/tasks/task_e_6869b3c8d6508333a76958ab4877a6e8