### PR TITLE
Add French translations and breadcrumb navigation

### DIFF
--- a/internal/ui/e2e/french.spec.js
+++ b/internal/ui/e2e/french.spec.js
@@ -1,0 +1,30 @@
+import { test, expect } from "@playwright/test";
+import { fileURLToPath } from "url";
+import path from "path";
+
+test.beforeEach(async ({ page }) => {
+  const dir = path.dirname(fileURLToPath(import.meta.url));
+  const scriptPath = path.join(dir, "mockDataService.js");
+  await page.addInitScript({ path: scriptPath });
+});
+
+test("switch UI language to French", async ({ page }) => {
+  await page.goto("/");
+
+  await page.getByRole("button", { name: "DE" }).click();
+  await page.getByRole("option", { name: "FR" }).click();
+
+  await expect(page.getByRole("tab", { name: "Projets" })).toBeVisible();
+  await expect(page.getByRole("tab", { name: "Revenus" })).toBeVisible();
+  await expect(page.getByRole("tab", { name: "Dépenses" })).toBeVisible();
+
+  await page.getByRole("tab", { name: "Projets" }).click();
+  await expect(page.getByLabel("Nouveau projet")).toBeVisible();
+  await expect(page.getByRole("button", { name: "Créer" })).toBeVisible();
+
+  await page.getByRole("tab", { name: "Revenus" }).click();
+  await expect(page.getByRole("heading", { name: "Nouveau revenu" })).toBeVisible();
+  await expect(page.getByLabel("Source")).toBeVisible();
+  await expect(page.getByLabel("Montant (€)" )).toBeVisible();
+  await expect(page.getByRole("button", { name: "Ajouter" })).toBeVisible();
+});

--- a/internal/ui/src/App.jsx
+++ b/internal/ui/src/App.jsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useCallback } from "react";
 import { ThemeProvider, createTheme } from "@mui/material/styles";
-import { CssBaseline, Container, FormControlLabel, Switch, AppBar, Toolbar, Typography, Tabs, Tab, Paper, Select, MenuItem, Snackbar, Alert } from "@mui/material";
+import { CssBaseline, Container, FormControlLabel, Switch, AppBar, Toolbar, Typography, Tabs, Tab, Paper, Select, MenuItem, Snackbar, Alert, Breadcrumbs } from "@mui/material";
 import { useTranslation } from "react-i18next";
 import "./i18n";
 import { ListExpenses, ListIncomes, AddIncome, UpdateIncome, DeleteIncome, AddExpense, UpdateExpense, DeleteExpense, AddMember, UpdateMember, ListMembers, DeleteMember } from "./wailsjs/go/service/DataService";
@@ -14,6 +14,8 @@ import MemberTable from "./components/MemberTable";
 import TaxPanel from "./components/TaxPanel";
 import FormsPanel from "./components/FormsPanel";
 import SettingsPanel from "./components/SettingsPanel";
+
+const tabKeys = ['tab.projects', 'tab.members', 'tab.incomes', 'tab.expenses', 'tab.forms', 'tab.taxes', 'tab.settings'];
 
 export default function App() {
   const [incomes, setIncomes] = useState([]);
@@ -68,6 +70,9 @@ export default function App() {
   useEffect(() => {
     fetchMembers();
   }, []);
+  useEffect(() => {
+    document.title = `Baristeuer - ${t(tabKeys[tab])}`;
+  }, [tab, i18n.language, t]);
 
   const submitIncome = async (source, amount, setError) => {
     try {
@@ -131,6 +136,7 @@ export default function App() {
           >
             <MenuItem value="de">DE</MenuItem>
             <MenuItem value="en">EN</MenuItem>
+            <MenuItem value="fr">FR</MenuItem>
           </Select>
           <FormControlLabel
             control={<Switch checked={darkMode} onChange={() => setDarkMode(!darkMode)} color="default" />}
@@ -148,6 +154,10 @@ export default function App() {
         </Tabs>
       </AppBar>
       <Container maxWidth="md" sx={{ py: 4 }}>
+        <Breadcrumbs aria-label="breadcrumb" sx={{ mb: 2 }}>
+          <Typography color="inherit">Baristeuer</Typography>
+          <Typography color="text.primary">{t(tabKeys[tab])}</Typography>
+        </Breadcrumbs>
         {tab === 0 && (
           <ProjectPanel activeId={projectId} onSelect={(id) => setProjectId(id)} />
         )}

--- a/internal/ui/src/App.test.jsx
+++ b/internal/ui/src/App.test.jsx
@@ -2,7 +2,7 @@ import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import { vi, beforeEach } from 'vitest';
 import App from './App';
-import './i18n';
+import i18n from './i18n';
 
 // mock the DataService module used by App
 vi.mock('./wailsjs/go/service/DataService', () => ({
@@ -48,6 +48,7 @@ import {
 
 beforeEach(() => {
   vi.clearAllMocks();
+  i18n.changeLanguage('de');
 });
 
 test('renders app heading', async () => {
@@ -263,4 +264,28 @@ test('deletes a member', async () => {
 
   await waitFor(() => expect(DeleteMember).toHaveBeenCalledWith(1));
   await waitFor(() => expect(screen.queryByText('Bob')).not.toBeInTheDocument());
+});
+
+test('changes language to French', async () => {
+  ListExpenses.mockResolvedValueOnce([]);
+  ListIncomes.mockResolvedValueOnce([]);
+  ListMembers.mockResolvedValueOnce([]);
+  render(<App />);
+  await screen.findByRole('heading', { name: /Baristeuer/i });
+
+  fireEvent.mouseDown(screen.getByRole('combobox'));
+  fireEvent.click(screen.getByRole('option', { name: 'FR' }));
+
+  expect(await screen.findByRole('tab', { name: 'Projets' })).toBeVisible();
+});
+
+test('updates document title on tab change', async () => {
+  ListExpenses.mockResolvedValueOnce([]);
+  ListIncomes.mockResolvedValueOnce([]);
+  ListMembers.mockResolvedValueOnce([]);
+  render(<App />);
+  await screen.findByRole('heading', { name: /Baristeuer/i });
+  expect(document.title).toContain('Einnahmen');
+  fireEvent.click(screen.getByRole('tab', { name: /Ausgaben/i }));
+  expect(document.title).toContain('Ausgaben');
 });

--- a/internal/ui/src/i18n.js
+++ b/internal/ui/src/i18n.js
@@ -2,6 +2,7 @@ import i18n from 'i18next';
 import { initReactI18next } from 'react-i18next';
 import de from './locales/de.json';
 import en from './locales/en.json';
+import fr from './locales/fr.json';
 
 i18n
   .use(initReactI18next)
@@ -9,6 +10,7 @@ i18n
     resources: {
       de: { translation: de },
       en: { translation: en },
+      fr: { translation: fr },
     },
     lng: 'de',
     fallbackLng: 'de',

--- a/internal/ui/src/locales/de.json
+++ b/internal/ui/src/locales/de.json
@@ -92,6 +92,7 @@
   "language": "Sprache",
   "language_de": "Deutsch",
   "language_en": "Englisch",
+  "language_fr": "Französisch",
   "edit": "Bearbeiten",
   "delete": "Löschen",
   "errors": {

--- a/internal/ui/src/locales/en.json
+++ b/internal/ui/src/locales/en.json
@@ -92,6 +92,7 @@
   "language": "Language",
   "language_de": "German",
   "language_en": "English",
+  "language_fr": "French",
   "edit": "Edit",
   "delete": "Delete",
   "errors": {

--- a/internal/ui/src/locales/fr.json
+++ b/internal/ui/src/locales/fr.json
@@ -1,0 +1,108 @@
+{
+  "theme": { "dark": "Sombre", "light": "Clair" },
+  "tab": {
+    "projects": "Projets",
+    "members": "Membres",
+    "incomes": "Revenus",
+    "expenses": "Dépenses",
+    "forms": "Formulaires",
+    "taxes": "Impôts",
+    "settings": "Paramètres"
+  },
+
+  "settings": {
+    "title": "Paramètres",
+    "export": "Exporter la base",
+    "restore": "Restaurer la base",
+    "csv": "Exporter CSV projet",
+    "select_log": "Niveau de log",
+    "log_format": "Format du log",
+    "apply": "Appliquer",
+    "exported": "Base exportée",
+    "restored": "Base restaurée",
+    "csv_exported": "CSV exporté",
+    "tax_year": "Année fiscale"
+  },
+  "income": {
+    "new": "Nouveau revenu",
+    "add": "Ajouter",
+    "source": "Source",
+    "amount": "Montant (€)",
+    "table": {
+      "source": "Source",
+      "amount": "Montant (€)",
+      "actions": "Actions",
+      "empty": "Aucun revenu"
+    }
+  },
+  "expense": {
+    "new": "Nouvelle dépense",
+    "add": "Ajouter",
+    "description": "Description",
+    "amount": "Montant (€)",
+    "table": {
+      "description": "Description",
+      "amount": "Montant (€)",
+      "actions": "Actions",
+      "empty": "Aucune dépense"
+    }
+  },
+  "project": {
+    "new": "Nouveau projet",
+    "create": "Créer",
+    "error": "Erreur lors de la création",
+    "delete": "Supprimer"
+  },
+  "member": {
+    "new": "Nouveau membre",
+    "add": "Ajouter",
+    "name": "Nom",
+    "email": "E-mail",
+    "joinDate": "Date d\u2019adhésion",
+    "table": {
+      "name": "Nom",
+      "email": "E-mail",
+      "joinDate": "Date d\u2019adhésion",
+      "actions": "Actions",
+      "empty": "Aucun membre"
+    }
+  },
+  "forms": {
+    "generate_all": "Générer tous les formulaires",
+    "error": "Erreur de génération"
+  },
+  "form": {
+    "generate": "Générer",
+    "kst1": "KSt 1",
+    "anlageGem": "Anlage Gem",
+    "anlageGK": "Anlage GK",
+    "kst1f": "KSt 1F",
+    "anlageSport": "Anlage Sport",
+    "detailedReport": "Rapport détaillé"
+  },
+  "tax": {
+    "calculate": "Calculer les impôts",
+    "revenue": "Revenus : {{value}} €",
+    "expenses": "Dépenses : {{value}} €",
+    "taxableIncome": "Revenu imposable : {{value}} €",
+    "totalTax": "Impôt total : {{value}} €",
+    "year": "Année",
+    "error": "Erreur de calcul"
+  },
+  "language": "Langue",
+  "language_de": "Allemand",
+  "language_en": "Anglais",
+  "language_fr": "Français",
+  "edit": "Éditer",
+  "delete": "Supprimer",
+  "errors": {
+    "income_required": "Source et montant requis",
+    "income_positive": "Le montant doit être positif",
+    "expense_required": "Description et montant requis",
+    "expense_positive": "Le montant doit être positif",
+    "member_required": "Nom et e-mail requis",
+    "member_invalid_email": "Adresse e-mail invalide",
+    "member_invalid_date": "Date invalide",
+    "add": "Erreur lors de l\u2019ajout"
+  }
+}


### PR DESCRIPTION
## Summary
- support French UI language
- show breadcrumbs and update page titles
- include French option in the language selector
- cover new language and navigation behaviour in unit and e2e tests

## Testing
- `npm test --prefix internal/ui`
- `go test ./cmd/... ./internal/... ./internal/pdf/...`
- `npm run lint --prefix internal/ui`


------
https://chatgpt.com/codex/tasks/task_e_6869b3c95e5483338ba236e9a760e2f7