### PR TITLE
Extend profiling script

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,3 +55,25 @@ jobs:
       - name: Go tests
         run: go test ./cmd/... ./internal/... ./internal/pdf/...
 
+  profile:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.22'
+      - name: Setup Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: '20'
+      - name: Sync Go workspace
+        run: go work sync
+      - name: Run profiling script
+        run: ./scripts/profile_service.sh
+      - name: Upload profile artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: bench-profiles
+          path: bench_profiles/*
+

--- a/README.md
+++ b/README.md
@@ -136,6 +136,18 @@ BenchmarkAddExpenseMass1e2-5   1230   968092 ns/op   55227 B/op   1500 allocs/op
 BenchmarkAddExpenseMass1e3-5    127  9727703 ns/op  552305 B/op  15001 allocs/op
 ```
 
+The `profile_service.sh` script now also benchmarks the React frontend. It writes
+build size, build time and page load metrics to files in `bench_profiles/`:
+
+```
+frontend_build_size.txt     # size of the dist directory
+frontend_build_seconds.txt  # seconds spent in `npm run build`
+frontend_load_seconds.txt   # page load time measured via curl
+```
+
+Inspect CPU or memory profiles with `go tool pprof bench_profiles/cpu.out`. Build
+and load metrics help track regressions in the bundle size and initial render.
+
 ## Docker
 
 You can also build Bari$teuer inside a container. Example commands:

--- a/scripts/profile_service.sh
+++ b/scripts/profile_service.sh
@@ -1,12 +1,39 @@
 #!/bin/sh
-# Run service benchmarks with CPU and memory profiling
+# Run service benchmarks with CPU and memory profiling and measure frontend metrics
 set -e
-cd "$(git rev-parse --show-toplevel)"
-PROFILE_DIR=${PROFILE_DIR:-bench_profiles}
+
+ROOT_DIR="$(git rev-parse --show-toplevel)"
+cd "$ROOT_DIR"
+
+PROFILE_DIR=${PROFILE_DIR:-$ROOT_DIR/bench_profiles}
 mkdir -p "$PROFILE_DIR"
-go test ./internal/service -bench=Mass -benchmem -cpuprofile "$PROFILE_DIR/cpu.out" -memprofile "$PROFILE_DIR/mem.out"
+
+# Backend benchmarks
+go test ./internal/service -bench=Mass -benchmem \
+    -cpuprofile "$PROFILE_DIR/cpu.out" \
+    -memprofile "$PROFILE_DIR/mem.out"
+
+# Frontend build size and load time
+cd internal/ui
+npm ci --silent
+START=$(date +%s)
+npm run build >/dev/null
+BUILD_TIME=$(( $(date +%s) - START ))
+BUILD_SIZE=$(du -sh dist | awk '{print $1}')
+npx vite preview --port 5173 >/dev/null 2>&1 &
+SERVER_PID=$!
+sleep 2
+curl -o /dev/null -s -w "%{time_total}\n" http://localhost:5173 > "$PROFILE_DIR/frontend_load_seconds.txt"
+kill $SERVER_PID
+echo "$BUILD_SIZE" > "$PROFILE_DIR/frontend_build_size.txt"
+echo "$BUILD_TIME" > "$PROFILE_DIR/frontend_build_seconds.txt"
+cd - >/dev/null
+
 cat <<MSG
 Profiles written to $PROFILE_DIR/cpu.out and $PROFILE_DIR/mem.out
-Use 'go tool pprof' to analyze the results, e.g.:
+Frontend build size written to $PROFILE_DIR/frontend_build_size.txt
+Build time written to $PROFILE_DIR/frontend_build_seconds.txt
+Page load time written to $PROFILE_DIR/frontend_load_seconds.txt
+Use 'go tool pprof' to analyze the Go profiles, e.g.:
   go tool pprof $PROFILE_DIR/cpu.out
 MSG


### PR DESCRIPTION
## Summary
- measure frontend build metrics in `profile_service.sh`
- publish profiling results in CI
- document how to interpret the profiles

## Testing
- `npm ci --prefix internal/ui`
- `npm test --prefix internal/ui`
- `go work sync`
- `go test ./cmd/... ./internal/... ./internal/pdf/...`
- `./scripts/profile_service.sh`


------
https://chatgpt.com/codex/tasks/task_e_6869b3c9f9ac8333acc78ab5ac86236f