### PR TITLE
Implement statistics reporting

### DIFF
--- a/go.work
+++ b/go.work
@@ -4,4 +4,5 @@ use (
 	./cmd
 	./internal
 	./internal/pdf
+	./internal/report
 )

--- a/internal/report/go.mod
+++ b/internal/report/go.mod
@@ -1,0 +1,3 @@
+module baristeuer/internal/report
+
+go 1.22

--- a/internal/report/report.go
+++ b/internal/report/report.go
@@ -1,0 +1,40 @@
+package report
+
+// Average returns the arithmetic mean of values or 0 for an empty slice.
+func Average(values []float64) float64 {
+	if len(values) == 0 {
+		return 0
+	}
+	var sum float64
+	for _, v := range values {
+		sum += v
+	}
+	return sum / float64(len(values))
+}
+
+// Trend returns the difference between the last and first value.
+func Trend(values []float64) float64 {
+	if len(values) < 2 {
+		return 0
+	}
+	return values[len(values)-1] - values[0]
+}
+
+type Statistics struct {
+	AverageIncome  float64
+	AverageExpense float64
+	Trend          float64
+	Year           int
+}
+
+// Calculate computes basic statistics from income and expense values.
+func Calculate(incomes, expenses []float64, year int) Statistics {
+	avgInc := Average(incomes)
+	avgExp := Average(expenses)
+	return Statistics{
+		AverageIncome:  avgInc,
+		AverageExpense: avgExp,
+		Trend:          avgInc - avgExp,
+		Year:           year,
+	}
+}

--- a/internal/report/report_test.go
+++ b/internal/report/report_test.go
@@ -1,0 +1,28 @@
+package report
+
+import "testing"
+
+func TestAverage(t *testing.T) {
+	if avg := Average([]float64{1, 2, 3}); avg != 2 {
+		t.Fatalf("expected 2 got %f", avg)
+	}
+	if Average(nil) != 0 {
+		t.Fatalf("expected 0 for empty slice")
+	}
+}
+
+func TestCalculate(t *testing.T) {
+	stats := Calculate([]float64{10, 20}, []float64{5, 15}, 2025)
+	if stats.AverageIncome != 15 {
+		t.Fatalf("avg income expected 15 got %f", stats.AverageIncome)
+	}
+	if stats.AverageExpense != 10 {
+		t.Fatalf("avg expense expected 10 got %f", stats.AverageExpense)
+	}
+	if stats.Trend != 5 {
+		t.Fatalf("trend expected 5 got %f", stats.Trend)
+	}
+	if stats.Year != 2025 {
+		t.Fatalf("year expected 2025 got %d", stats.Year)
+	}
+}

--- a/internal/service/service_test.go
+++ b/internal/service/service_test.go
@@ -185,6 +185,29 @@ func TestDataService_CalculateProjectTaxes(t *testing.T) {
 	}
 }
 
+func TestDataService_GenerateStatistics(t *testing.T) {
+	ds, err := NewDataService(":memory:", slog.New(slog.NewTextHandler(io.Discard, nil)), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ds.Close()
+
+	ctx := context.Background()
+	proj, _ := ds.CreateProject(ctx, "Stats")
+	ds.AddIncome(ctx, proj.ID, "donation", 10)
+	ds.AddIncome(ctx, proj.ID, "donation", 20)
+	ds.AddExpense(ctx, proj.ID, "rent", 5)
+	ds.AddExpense(ctx, proj.ID, "rent", 15)
+
+	stats, err := ds.GenerateStatistics(ctx, proj.ID, 2025)
+	if err != nil {
+		t.Fatalf("GenerateStatistics returned error: %v", err)
+	}
+	if stats.AverageIncome != 15 || stats.AverageExpense != 10 || stats.Trend != 5 || stats.Year != 2025 {
+		t.Fatalf("unexpected stats: %+v", stats)
+	}
+}
+
 func TestDataService_MemberOperations(t *testing.T) {
 	ds, err := NewDataService(":memory:", slog.New(slog.NewTextHandler(io.Discard, nil)), nil)
 	if err != nil {

--- a/internal/ui/package-lock.json
+++ b/internal/ui/package-lock.json
@@ -11,8 +11,10 @@
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.14.1",
         "@mui/material": "^5.15.8",
+        "chart.js": "^4.5.0",
         "i18next": "^23.10.0",
         "react": "^19.1.0",
+        "react-chartjs-2": "^5.3.0",
         "react-dom": "^19.1.0",
         "react-i18next": "^13.2.1"
       },
@@ -1316,6 +1318,12 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@kurkle/color": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@kurkle/color/-/color-0.3.4.tgz",
+      "integrity": "sha512-M5UknZPHRu3DEDWoipU6sE8PdkZ6Z/S+v4dD+Ke8IaNlpdSQah50lz1KtcFBa2vsdOnwbbnxJwVM4wty6udA5w==",
+      "license": "MIT"
+    },
     "node_modules/@mui/core-downloads-tracker": {
       "version": "5.17.1",
       "resolved": "https://registry.npmjs.org/@mui/core-downloads-tracker/-/core-downloads-tracker-5.17.1.tgz",
@@ -2433,6 +2441,18 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/chart.js": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-4.5.0.tgz",
+      "integrity": "sha512-aYeC/jDgSEx8SHWZvANYMioYMZ2KX02W6f6uVfyteuCGcadDLcYVHdfdygsTQkQ4TKn5lghoojAsPj5pu0SnvQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@kurkle/color": "^0.3.0"
+      },
+      "engines": {
+        "pnpm": ">=8"
       }
     },
     "node_modules/check-error": {
@@ -4203,6 +4223,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-chartjs-2": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/react-chartjs-2/-/react-chartjs-2-5.3.0.tgz",
+      "integrity": "sha512-UfZZFnDsERI3c3CZGxzvNJd02SHjaSJ8kgW1djn65H1KK8rehwTjyrRKOG3VTMG8wtHZ5rgAO5oTHtHi9GCCmw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "chart.js": "^4.1.1",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/react-dom": {

--- a/internal/ui/package.json
+++ b/internal/ui/package.json
@@ -16,8 +16,10 @@
     "@emotion/react": "^11.14.0",
     "@emotion/styled": "^11.14.1",
     "@mui/material": "^5.15.8",
+    "chart.js": "^4.5.0",
     "i18next": "^23.10.0",
     "react": "^19.1.0",
+    "react-chartjs-2": "^5.3.0",
     "react-dom": "^19.1.0",
     "react-i18next": "^13.2.1"
   },

--- a/internal/ui/src/App.jsx
+++ b/internal/ui/src/App.jsx
@@ -14,6 +14,7 @@ import MemberTable from "./components/MemberTable";
 import TaxPanel from "./components/TaxPanel";
 import FormsPanel from "./components/FormsPanel";
 import SettingsPanel from "./components/SettingsPanel";
+import ReportPanel from "./components/ReportPanel";
 
 export default function App() {
   const [incomes, setIncomes] = useState([]);
@@ -144,6 +145,7 @@ export default function App() {
           <Tab label={t('tab.expenses')} />
           <Tab label={t('tab.forms')} />
           <Tab label={t('tab.taxes')} />
+          <Tab label={t('tab.reports')} />
           <Tab label={t('tab.settings')} />
         </Tabs>
       </AppBar>
@@ -218,6 +220,11 @@ export default function App() {
           </Paper>
         )}
         {tab === 6 && (
+          <Paper sx={{ p: 3 }}>
+            <ReportPanel projectId={projectId} />
+          </Paper>
+        )}
+        {tab === 7 && (
           <Paper sx={{ p: 3 }}>
             <SettingsPanel projectId={projectId} />
           </Paper>

--- a/internal/ui/src/components/ReportPanel.jsx
+++ b/internal/ui/src/components/ReportPanel.jsx
@@ -1,0 +1,55 @@
+import { useEffect, useState } from "react";
+import { Box, Typography } from "@mui/material";
+import { Bar } from "react-chartjs-2";
+import {
+  Chart,
+  CategoryScale,
+  LinearScale,
+  BarElement,
+  Title,
+  Tooltip,
+  Legend,
+} from "chart.js";
+import { GenerateStatistics } from "../wailsjs/go/service/DataService";
+import { useTranslation } from "react-i18next";
+
+Chart.register(CategoryScale, LinearScale, BarElement, Title, Tooltip, Legend);
+
+export default function ReportPanel({ projectId }) {
+  const [stats, setStats] = useState(null);
+  const { t } = useTranslation();
+
+  useEffect(() => {
+    const load = async () => {
+      try {
+        const s = await GenerateStatistics(projectId, 2025);
+        setStats(s);
+      } catch (err) {
+        console.error(err);
+      }
+    };
+    load();
+  }, [projectId]);
+
+  if (!stats) return null;
+
+  const data = {
+    labels: [t("reports.avgIncome"), t("reports.avgExpense")],
+    datasets: [
+      {
+        label: t("reports.average"),
+        data: [stats.averageIncome, stats.averageExpense],
+        backgroundColor: ["#1976d2", "#9c27b0"],
+      },
+    ],
+  };
+
+  return (
+    <Box>
+      <Bar data={data} />
+      <Typography sx={{ mt: 2 }}>
+        {t("reports.trend", { value: stats.trend.toFixed(2) })}
+      </Typography>
+    </Box>
+  );
+}

--- a/internal/ui/src/components/ReportPanel.test.jsx
+++ b/internal/ui/src/components/ReportPanel.test.jsx
@@ -1,0 +1,21 @@
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { vi } from 'vitest';
+import ReportPanel from './ReportPanel';
+import '../i18n';
+
+vi.mock('../wailsjs/go/service/DataService', () => ({
+  GenerateStatistics: vi.fn(),
+}), { virtual: true });
+
+import { GenerateStatistics } from '../wailsjs/go/service/DataService';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+test('renders statistics', async () => {
+  GenerateStatistics.mockResolvedValue({ averageIncome: 10, averageExpense: 5, trend: 5 });
+  render(<ReportPanel projectId={1} />);
+  expect(await screen.findByText(/Trend/i)).toBeInTheDocument();
+});

--- a/internal/ui/src/locales/de.json
+++ b/internal/ui/src/locales/de.json
@@ -7,6 +7,7 @@
     "expenses": "Ausgaben",
     "forms": "Formulare",
     "taxes": "Steuern",
+    "reports": "Berichte",
     "settings": "Einstellungen"
   },
 
@@ -88,6 +89,12 @@
     "totalTax": "Gesamtsteuer: {{value}} €",
     "year": "Jahr",
     "error": "Fehler bei Berechnung"
+  },
+  "reports": {
+    "average": "Durchschnitt",
+    "avgIncome": "Ø Einnahmen",
+    "avgExpense": "Ø Ausgaben",
+    "trend": "Trend: {{value}}"
   },
   "language": "Sprache",
   "language_de": "Deutsch",

--- a/internal/ui/src/locales/en.json
+++ b/internal/ui/src/locales/en.json
@@ -7,6 +7,7 @@
     "expenses": "Expenses",
     "forms": "Forms",
     "taxes": "Taxes",
+    "reports": "Reports",
     "settings": "Settings"
   },
 
@@ -88,6 +89,12 @@
     "totalTax": "Total tax: {{value}} €",
     "year": "Year",
     "error": "Error calculating"
+  },
+  "reports": {
+    "average": "Average",
+    "avgIncome": "Avg Income",
+    "avgExpense": "Avg Expense",
+    "trend": "Trend: {{value}}"
   },
   "language": "Language",
   "language_de": "German",

--- a/internal/ui/src/wailsjs/go/service/DataService.js
+++ b/internal/ui/src/wailsjs/go/service/DataService.js
@@ -93,3 +93,7 @@ export function SetLogFormat(arg1) {
 export function ExportProjectCSV(arg1, arg2) {
   return window.go.service.DataService.ExportProjectCSV(arg1, arg2);
 }
+
+export function GenerateStatistics(arg1, arg2) {
+  return window.go.service.DataService.GenerateStatistics(arg1, arg2);
+}


### PR DESCRIPTION
## Summary
- add `internal/report` module with basic statistic functions
- extend `DataService` with `GenerateStatistics`
- provide new `ReportPanel` React component with charts
- localize new UI strings and show reports tab
- update autogenerated Wails bindings
- add tests for statistics and frontend

## Testing
- `go test ./cmd/... ./internal/... ./internal/pdf/...`
- `npm test --prefix internal/ui`


------
https://chatgpt.com/codex/tasks/task_e_6869b3c7c8888333be68807347c6ae87