### PR TITLE
Fix service tests for new DataService signature

### DIFF
--- a/internal/service/service_test.go
+++ b/internal/service/service_test.go
@@ -186,7 +186,7 @@ func TestDataService_CalculateProjectTaxes(t *testing.T) {
 }
 
 func TestDataService_GenerateStatistics(t *testing.T) {
-	ds, err := NewDataService(":memory:", slog.New(slog.NewTextHandler(io.Discard, nil)), nil)
+	ds, err := NewDataService(":memory:", slog.New(slog.NewTextHandler(io.Discard, nil)), nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
## Summary
- update `NewDataService` call in `service_test.go` to pass `nil` for new cfg parameter

## Testing
- `go test ./cmd/... ./internal/... ./internal/pdf/...`


------
https://chatgpt.com/codex/tasks/task_e_6869bb2a08348333b704d523655d7409