### PR TITLE
Add RemoteClient config support and tests

### DIFF
--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -26,7 +26,7 @@ func validateAmount(amount float64) error {
 
 func selectSyncClient(cfg *config.Config) syncsvc.Client {
 	if cfg != nil && cfg.CloudUploadURL != "" && cfg.CloudDownloadURL != "" {
-		return syncsvc.NewRemoteClient(cfg.CloudUploadURL, cfg.CloudDownloadURL, cfg.CloudToken)
+		return syncsvc.NewRemoteClientFromConfig(cfg)
 	}
 	return syncsvc.NewLocalClient("")
 }

--- a/internal/service/service_test.go
+++ b/internal/service/service_test.go
@@ -186,7 +186,7 @@ func TestDataService_CalculateProjectTaxes(t *testing.T) {
 }
 
 func TestDataService_GenerateStatistics(t *testing.T) {
-	ds, err := NewDataService(":memory:", slog.New(slog.NewTextHandler(io.Discard, nil)), nil)
+	ds, err := NewDataService(":memory:", slog.New(slog.NewTextHandler(io.Discard, nil)), nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/sync/client_test.go
+++ b/internal/sync/client_test.go
@@ -1,0 +1,61 @@
+package sync
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+
+	"baristeuer/internal/config"
+)
+
+func TestRemoteClient_UploadDownload(t *testing.T) {
+	uploadCalled := false
+	downloadContent := []byte("dbdata")
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") != "Bearer token" {
+			t.Fatalf("missing auth header")
+		}
+		if r.Method == http.MethodPost {
+			uploadCalled = true
+			body, _ := io.ReadAll(r.Body)
+			if string(body) != "test" {
+				t.Fatalf("unexpected upload body: %s", body)
+			}
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		if r.Method == http.MethodGet {
+			w.Write(downloadContent)
+			return
+		}
+	}))
+	defer srv.Close()
+
+	f := "testfile"
+	os.WriteFile(f, []byte("test"), 0o644)
+	defer os.Remove(f)
+
+	cfg := &config.Config{CloudUploadURL: srv.URL, CloudDownloadURL: srv.URL, CloudToken: "token"}
+	c := NewRemoteClientFromConfig(cfg)
+	ctx := context.Background()
+	if err := c.Upload(ctx, f); err != nil {
+		t.Fatalf("upload error: %v", err)
+	}
+	if !uploadCalled {
+		t.Fatal("upload handler not called")
+	}
+
+	dest := "out"
+	defer os.Remove(dest)
+	if err := c.Download(ctx, dest); err != nil {
+		t.Fatalf("download error: %v", err)
+	}
+	data, _ := os.ReadFile(dest)
+	if string(data) != string(downloadContent) {
+		t.Fatalf("unexpected downloaded data: %s", data)
+	}
+}

--- a/internal/sync/sync.go
+++ b/internal/sync/sync.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 
 	"baristeuer/internal/cloud"
+	"baristeuer/internal/config"
 )
 
 // Client defines upload and download operations for the database.
@@ -64,6 +65,15 @@ type RemoteClient struct{ c *cloud.Client }
 // NewRemoteClient constructs a RemoteClient for the given endpoints and token.
 func NewRemoteClient(uploadURL, downloadURL, token string) *RemoteClient {
 	return &RemoteClient{c: cloud.NewClient(uploadURL, downloadURL, token)}
+}
+
+// NewRemoteClientFromConfig constructs a RemoteClient using the cloud settings
+// defined in cfg. If cfg is nil, an empty client is returned.
+func NewRemoteClientFromConfig(cfg *config.Config) *RemoteClient {
+	if cfg == nil {
+		return NewRemoteClient("", "", "")
+	}
+	return NewRemoteClient(cfg.CloudUploadURL, cfg.CloudDownloadURL, cfg.CloudToken)
 }
 
 func (c *RemoteClient) Upload(ctx context.Context, src string) error {


### PR DESCRIPTION
## Summary
- add `NewRemoteClientFromConfig` for convenience
- use `NewRemoteClientFromConfig` in `DataService`
- fix `TestDataService_GenerateStatistics` parameter list
- add tests for `sync.RemoteClient`

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6869bb2bec4c83339aac2c0ec8a303d0