### PR TITLE
Add median and standard deviation reporting

### DIFF
--- a/internal/report/report.go
+++ b/internal/report/report.go
@@ -1,5 +1,10 @@
 package report
 
+import (
+	"math"
+	"sort"
+)
+
 // Average returns the arithmetic mean of values or 0 for an empty slice.
 func Average(values []float64) float64 {
 	if len(values) == 0 {
@@ -20,9 +25,42 @@ func Trend(values []float64) float64 {
 	return values[len(values)-1] - values[0]
 }
 
+// Median returns the middle value or the mean of the two middle values.
+func Median(values []float64) float64 {
+	if len(values) == 0 {
+		return 0
+	}
+	sorted := append([]float64(nil), values...)
+	sort.Float64s(sorted)
+	mid := len(sorted) / 2
+	if len(sorted)%2 == 0 {
+		return (sorted[mid-1] + sorted[mid]) / 2
+	}
+	return sorted[mid]
+}
+
+// StandardDeviation returns the population standard deviation.
+func StandardDeviation(values []float64) float64 {
+	if len(values) == 0 {
+		return 0
+	}
+	mean := Average(values)
+	var sum float64
+	for _, v := range values {
+		diff := v - mean
+		sum += diff * diff
+	}
+	variance := sum / float64(len(values))
+	return math.Sqrt(variance)
+}
+
 type Statistics struct {
 	AverageIncome  float64
 	AverageExpense float64
+	MedianIncome   float64
+	MedianExpense  float64
+	StdDevIncome   float64
+	StdDevExpense  float64
 	Trend          float64
 	Year           int
 }
@@ -34,6 +72,10 @@ func Calculate(incomes, expenses []float64, year int) Statistics {
 	return Statistics{
 		AverageIncome:  avgInc,
 		AverageExpense: avgExp,
+		MedianIncome:   Median(incomes),
+		MedianExpense:  Median(expenses),
+		StdDevIncome:   StandardDeviation(incomes),
+		StdDevExpense:  StandardDeviation(expenses),
 		Trend:          avgInc - avgExp,
 		Year:           year,
 	}

--- a/internal/report/report_test.go
+++ b/internal/report/report_test.go
@@ -11,6 +11,27 @@ func TestAverage(t *testing.T) {
 	}
 }
 
+func TestMedian(t *testing.T) {
+	if m := Median([]float64{1, 3, 2}); m != 2 {
+		t.Fatalf("expected 2 got %f", m)
+	}
+	if m := Median([]float64{1, 2, 3, 4}); m != 2.5 {
+		t.Fatalf("expected 2.5 got %f", m)
+	}
+	if Median(nil) != 0 {
+		t.Fatalf("expected 0 for empty slice")
+	}
+}
+
+func TestStandardDeviation(t *testing.T) {
+	if sd := StandardDeviation([]float64{2, 4}); sd != 1 {
+		t.Fatalf("expected 1 got %f", sd)
+	}
+	if StandardDeviation(nil) != 0 {
+		t.Fatalf("expected 0 for empty slice")
+	}
+}
+
 func TestCalculate(t *testing.T) {
 	stats := Calculate([]float64{10, 20}, []float64{5, 15}, 2025)
 	if stats.AverageIncome != 15 {
@@ -18,6 +39,18 @@ func TestCalculate(t *testing.T) {
 	}
 	if stats.AverageExpense != 10 {
 		t.Fatalf("avg expense expected 10 got %f", stats.AverageExpense)
+	}
+	if stats.MedianIncome != 15 {
+		t.Fatalf("median income expected 15 got %f", stats.MedianIncome)
+	}
+	if stats.MedianExpense != 10 {
+		t.Fatalf("median expense expected 10 got %f", stats.MedianExpense)
+	}
+	if stats.StdDevIncome != 5 {
+		t.Fatalf("stddev income expected 5 got %f", stats.StdDevIncome)
+	}
+	if stats.StdDevExpense != 5 {
+		t.Fatalf("stddev expense expected 5 got %f", stats.StdDevExpense)
 	}
 	if stats.Trend != 5 {
 		t.Fatalf("trend expected 5 got %f", stats.Trend)

--- a/internal/service/service_test.go
+++ b/internal/service/service_test.go
@@ -186,7 +186,7 @@ func TestDataService_CalculateProjectTaxes(t *testing.T) {
 }
 
 func TestDataService_GenerateStatistics(t *testing.T) {
-	ds, err := NewDataService(":memory:", slog.New(slog.NewTextHandler(io.Discard, nil)), nil)
+	ds, err := NewDataService(":memory:", slog.New(slog.NewTextHandler(io.Discard, nil)), nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -203,7 +203,10 @@ func TestDataService_GenerateStatistics(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GenerateStatistics returned error: %v", err)
 	}
-	if stats.AverageIncome != 15 || stats.AverageExpense != 10 || stats.Trend != 5 || stats.Year != 2025 {
+	if stats.AverageIncome != 15 || stats.AverageExpense != 10 ||
+		stats.MedianIncome != 15 || stats.MedianExpense != 10 ||
+		stats.StdDevIncome != 5 || stats.StdDevExpense != 5 ||
+		stats.Trend != 5 || stats.Year != 2025 {
 		t.Fatalf("unexpected stats: %+v", stats)
 	}
 }

--- a/internal/ui/src/components/ReportPanel.jsx
+++ b/internal/ui/src/components/ReportPanel.jsx
@@ -39,7 +39,17 @@ export default function ReportPanel({ projectId }) {
       {
         label: t("reports.average"),
         data: [stats.averageIncome, stats.averageExpense],
-        backgroundColor: ["#1976d2", "#9c27b0"],
+        backgroundColor: "#1976d2",
+      },
+      {
+        label: t("reports.median"),
+        data: [stats.medianIncome, stats.medianExpense],
+        backgroundColor: "#9c27b0",
+      },
+      {
+        label: t("reports.stdDev"),
+        data: [stats.stdDevIncome, stats.stdDevExpense],
+        backgroundColor: "#ff9800",
       },
     ],
   };

--- a/internal/ui/src/components/ReportPanel.test.jsx
+++ b/internal/ui/src/components/ReportPanel.test.jsx
@@ -1,21 +1,34 @@
-import { render, screen } from '@testing-library/react';
-import '@testing-library/jest-dom';
-import { vi } from 'vitest';
-import ReportPanel from './ReportPanel';
-import '../i18n';
+import { render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import { vi } from "vitest";
+import ReportPanel from "./ReportPanel";
+import "../i18n";
 
-vi.mock('../wailsjs/go/service/DataService', () => ({
-  GenerateStatistics: vi.fn(),
-}), { virtual: true });
+vi.mock(
+  "../wailsjs/go/service/DataService",
+  () => ({
+    GenerateStatistics: vi.fn(),
+  }),
+  { virtual: true },
+);
 
-import { GenerateStatistics } from '../wailsjs/go/service/DataService';
+import { GenerateStatistics } from "../wailsjs/go/service/DataService";
 
 beforeEach(() => {
   vi.clearAllMocks();
 });
 
-test('renders statistics', async () => {
-  GenerateStatistics.mockResolvedValue({ averageIncome: 10, averageExpense: 5, trend: 5 });
+test("renders statistics", async () => {
+  GenerateStatistics.mockResolvedValue({
+    averageIncome: 10,
+    averageExpense: 5,
+    medianIncome: 10,
+    medianExpense: 5,
+    stdDevIncome: 0,
+    stdDevExpense: 0,
+    trend: 5,
+  });
   render(<ReportPanel projectId={1} />);
   expect(await screen.findByText(/Trend/i)).toBeInTheDocument();
+  expect(screen.getByRole("img")).toBeInTheDocument();
 });

--- a/internal/ui/src/locales/de.json
+++ b/internal/ui/src/locales/de.json
@@ -94,6 +94,8 @@
     "average": "Durchschnitt",
     "avgIncome": "Ø Einnahmen",
     "avgExpense": "Ø Ausgaben",
+    "median": "Median",
+    "stdDev": "Standardabweichung",
     "trend": "Trend: {{value}}"
   },
   "language": "Sprache",

--- a/internal/ui/src/locales/en.json
+++ b/internal/ui/src/locales/en.json
@@ -94,6 +94,8 @@
     "average": "Average",
     "avgIncome": "Avg Income",
     "avgExpense": "Avg Expense",
+    "median": "Median",
+    "stdDev": "Std Dev",
     "trend": "Trend: {{value}}"
   },
   "language": "Language",


### PR DESCRIPTION
## Summary
- compute median and standard deviation in `internal/report`
- display averages, medians and standard deviations in `ReportPanel`
- localize new labels in en/de translations
- adapt tests for new statistics

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6869bb2ef65483339713991b11d1053f