### PR TITLE
Add more E2E tests

### DIFF
--- a/internal/ui/e2e/export-error.spec.js
+++ b/internal/ui/e2e/export-error.spec.js
@@ -1,0 +1,22 @@
+import { test, expect } from "@playwright/test";
+import { fileURLToPath } from "url";
+import path from "path";
+
+test.beforeEach(async ({ page }) => {
+  const dir = path.dirname(fileURLToPath(import.meta.url));
+  await page.addInitScript({ path: path.join(dir, "mockDataService.js") });
+  await page.addInitScript({ path: path.join(dir, "mockFailCSV.js") });
+});
+
+test("show error if CSV export fails", async ({ page }) => {
+  await page.goto("/");
+
+  await page.getByRole("textbox", { name: /Neues Projekt/i }).fill("Demo");
+  await page.getByRole("button", { name: /Erstellen/i }).click();
+
+  await page.getByRole("tab", { name: /Einstellungen/i }).click();
+  await page.getByLabel(/Projekt-CSV exportieren/i).fill("fail.csv");
+  await page.getByRole("button", { name: /Projekt-CSV exportieren/i }).click();
+
+  await expect(page.getByText("CSV export failed")).toBeVisible();
+});

--- a/internal/ui/e2e/language_forms.spec.js
+++ b/internal/ui/e2e/language_forms.spec.js
@@ -1,0 +1,32 @@
+import { test, expect } from "@playwright/test";
+import { fileURLToPath } from "url";
+import path from "path";
+
+test.beforeEach(async ({ page }) => {
+  const dir = path.dirname(fileURLToPath(import.meta.url));
+  await page.addInitScript({ path: path.join(dir, "mockDataService.js") });
+  await page.addInitScript({ path: path.join(dir, "mockPDFGenerator.js") });
+});
+
+test("switch languages and generate forms", async ({ page }) => {
+  await page.goto("/");
+
+  await page.getByRole("textbox", { name: /Neues Projekt/i }).fill("Demo");
+  await page.getByRole("button", { name: /Erstellen/i }).click();
+
+  // switch to English and generate
+  await page.getByRole("button", { name: "DE" }).click();
+  await page.getByRole("option", { name: "EN" }).click();
+  await page.getByRole("tab", { name: "Forms" }).click();
+  await page.getByRole("button", { name: /Generate All Forms/i }).click();
+
+  // switch back to German and generate again
+  await page.getByRole("button", { name: "EN" }).click();
+  await page.getByRole("option", { name: "DE" }).click();
+  await page.getByRole("tab", { name: /Formulare/i }).click();
+  await page.getByRole("button", { name: /Alle Formulare erstellen/i }).click();
+
+  const calls = await page.evaluate(() => window.__pdfCalls);
+  const count = calls.filter((c) => c.name === "GenerateAllForms").length;
+  expect(count).toBe(2);
+});

--- a/internal/ui/e2e/mockFailCSV.js
+++ b/internal/ui/e2e/mockFailCSV.js
@@ -1,0 +1,8 @@
+(() => {
+  const svc = window.go && window.go.service && window.go.service.DataService;
+  if (svc) {
+    svc.ExportProjectCSV = async () => {
+      throw new Error("CSV export failed");
+    };
+  }
+})();

--- a/internal/ui/playwright.config.js
+++ b/internal/ui/playwright.config.js
@@ -1,9 +1,24 @@
-import { defineConfig } from "@playwright/test";
+import { defineConfig, devices } from "@playwright/test";
 
 export default defineConfig({
   testDir: "./e2e",
   testMatch: ["**/*.spec.js"],
   timeout: 30000,
+  fullyParallel: true,
+  projects: [
+    {
+      name: "chromium",
+      use: { ...devices["Desktop Chrome"] },
+    },
+    {
+      name: "firefox",
+      use: { ...devices["Desktop Firefox"] },
+    },
+    {
+      name: "webkit",
+      use: { ...devices["Desktop Safari"] },
+    },
+  ],
   use: {
     baseURL: "http://localhost:5173",
     headless: true,


### PR DESCRIPTION
## Summary
- add a test that toggles the language and generates forms
- test CSV export error handling using a mock service
- enable cross-browser Playwright projects

## Testing
- `npm test --prefix internal/ui`
- `npm run test:e2e --prefix internal/ui` *(fails: browser binaries missing)*
- `npx playwright install chromium firefox webkit` *(fails: network or prompt issue)*

------
https://chatgpt.com/codex/tasks/task_e_686a53272cc883338f5f7aef1bbeb8e9