### PR TITLE
Add statistics chart for reports

### DIFF
--- a/internal/ui/src/App.jsx
+++ b/internal/ui/src/App.jsx
@@ -15,6 +15,7 @@ import TaxPanel from "./components/TaxPanel";
 import FormsPanel from "./components/FormsPanel";
 import SettingsPanel from "./components/SettingsPanel";
 import ReportPanel from "./components/ReportPanel";
+import StatisticsChart from "./components/StatisticsChart";
 
 export default function App() {
   const [incomes, setIncomes] = useState([]);
@@ -222,6 +223,7 @@ export default function App() {
         {tab === 6 && (
           <Paper sx={{ p: 3 }}>
             <ReportPanel projectId={projectId} />
+            <StatisticsChart projectId={projectId} />
           </Paper>
         )}
         {tab === 7 && (

--- a/internal/ui/src/components/StatisticsChart.jsx
+++ b/internal/ui/src/components/StatisticsChart.jsx
@@ -1,0 +1,79 @@
+import { useEffect, useState } from "react";
+import { Box } from "@mui/material";
+import { Line } from "react-chartjs-2";
+import {
+  Chart,
+  CategoryScale,
+  LinearScale,
+  PointElement,
+  LineElement,
+  Title,
+  Tooltip,
+  Legend,
+} from "chart.js";
+import { GenerateStatistics } from "../wailsjs/go/service/DataService";
+import { useTranslation } from "react-i18next";
+
+Chart.register(
+  CategoryScale,
+  LinearScale,
+  PointElement,
+  LineElement,
+  Title,
+  Tooltip,
+  Legend,
+);
+
+export default function StatisticsChart({ projectId }) {
+  const [stats, setStats] = useState(null);
+  const { t } = useTranslation();
+
+  useEffect(() => {
+    const load = async () => {
+      try {
+        const s = await GenerateStatistics(projectId, 2025);
+        setStats(s);
+      } catch (err) {
+        console.error(err);
+      }
+    };
+    load();
+  }, [projectId]);
+
+  if (!stats) return null;
+
+  const trendLabel = t("reports.trend", { value: "" }).replace(/[:\s]*$/, "");
+
+  const data = {
+    labels: [t("reports.avgIncome"), t("reports.avgExpense")],
+    datasets: [
+      {
+        label: t("reports.average"),
+        data: [stats.averageIncome, stats.averageExpense],
+        borderColor: "#1976d2",
+        backgroundColor: "rgba(25,118,210,0.5)",
+        tension: 0.3,
+      },
+      {
+        label: t("reports.median"),
+        data: [stats.medianIncome, stats.medianExpense],
+        borderColor: "#9c27b0",
+        backgroundColor: "rgba(156,39,176,0.5)",
+        tension: 0.3,
+      },
+      {
+        label: trendLabel,
+        data: [stats.trend, stats.trend],
+        borderColor: "#ff9800",
+        backgroundColor: "rgba(255,152,0,0.5)",
+        tension: 0.3,
+      },
+    ],
+  };
+
+  return (
+    <Box sx={{ mt: 3 }}>
+      <Line data={data} />
+    </Box>
+  );
+}

--- a/internal/ui/src/components/StatisticsChart.test.jsx
+++ b/internal/ui/src/components/StatisticsChart.test.jsx
@@ -1,0 +1,33 @@
+import { render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import { vi } from "vitest";
+import StatisticsChart from "./StatisticsChart";
+import "../i18n";
+
+vi.mock(
+  "../wailsjs/go/service/DataService",
+  () => ({
+    GenerateStatistics: vi.fn(),
+  }),
+  { virtual: true },
+);
+
+import { GenerateStatistics } from "../wailsjs/go/service/DataService";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+test("renders line chart", async () => {
+  GenerateStatistics.mockResolvedValue({
+    averageIncome: 10,
+    averageExpense: 5,
+    medianIncome: 9,
+    medianExpense: 4,
+    stdDevIncome: 0,
+    stdDevExpense: 0,
+    trend: 6,
+  });
+  render(<StatisticsChart projectId={1} />);
+  expect(await screen.findByRole("img")).toBeInTheDocument();
+});


### PR DESCRIPTION
## Summary
- create `StatisticsChart` component to display averages, medians and trend
- mount the chart in the Reports tab
- test the new component

## Testing
- `npm ci --prefix internal/ui`
- `npm test --prefix internal/ui`

------
https://chatgpt.com/codex/tasks/task_e_686a5325c6d883338e4ce51a44c8a9e5