### PR TITLE
Add extended settings fields and config handlers

### DIFF
--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -37,6 +37,7 @@ type DataService struct {
 	logger     *slog.Logger
 	logCloser  io.Closer
 	syncClient syncsvc.Client
+	cfg        *config.Config
 }
 
 // NewDataService creates a new service with the given datastore location.
@@ -48,8 +49,11 @@ func NewDataService(dsn string, logger *slog.Logger, closer io.Closer, cfg *conf
 	if logger == nil {
 		logger, closer = NewLogger("", "info", "text")
 	}
+	if cfg == nil {
+		cfg = &config.Config{}
+	}
 	client := selectSyncClient(cfg)
-	return &DataService{store: s, logger: logger, logCloser: closer, syncClient: client}, nil
+	return &DataService{store: s, logger: logger, logCloser: closer, syncClient: client, cfg: cfg}, nil
 }
 
 // NewDataServiceFromStore wraps an existing store.
@@ -57,8 +61,11 @@ func NewDataServiceFromStore(store *data.Store, logger *slog.Logger, closer io.C
 	if logger == nil {
 		logger, closer = NewLogger("", "info", "text")
 	}
+	if cfg == nil {
+		cfg = &config.Config{}
+	}
 	client := selectSyncClient(cfg)
-	return &DataService{store: store, logger: logger, logCloser: closer, syncClient: client}
+	return &DataService{store: store, logger: logger, logCloser: closer, syncClient: client, cfg: cfg}
 }
 
 // CreateProject creates a project by name.
@@ -403,6 +410,57 @@ func (ds *DataService) ExportProjectCSV(ctx context.Context, projectID int64, de
 	}
 	ds.logger.Info("exported csv", "project", projectID, "dest", dest)
 	return nil
+}
+
+// GetFormName returns the configured form name.
+func (ds *DataService) GetFormName() string { return ds.cfg.FormName }
+
+// SetFormName updates the configured form name.
+func (ds *DataService) SetFormName(name string) { ds.cfg.FormName = name }
+
+// GetFormTaxNumber returns the configured form tax number.
+func (ds *DataService) GetFormTaxNumber() string { return ds.cfg.FormTaxNumber }
+
+// SetFormTaxNumber updates the configured form tax number.
+func (ds *DataService) SetFormTaxNumber(num string) { ds.cfg.FormTaxNumber = num }
+
+// GetFormAddress returns the configured form address.
+func (ds *DataService) GetFormAddress() string { return ds.cfg.FormAddress }
+
+// SetFormAddress updates the configured form address.
+func (ds *DataService) SetFormAddress(addr string) { ds.cfg.FormAddress = addr }
+
+// GetTaxYear returns the current tax year.
+func (ds *DataService) GetTaxYear() int { return ds.cfg.TaxYear }
+
+// SetTaxYear updates the active tax year.
+func (ds *DataService) SetTaxYear(year int) { ds.cfg.TaxYear = year }
+
+// GetCloudUploadURL returns the configured cloud upload URL.
+func (ds *DataService) GetCloudUploadURL() string { return ds.cfg.CloudUploadURL }
+
+// SetCloudUploadURL updates the cloud upload URL and sync client.
+func (ds *DataService) SetCloudUploadURL(url string) {
+	ds.cfg.CloudUploadURL = url
+	ds.syncClient = selectSyncClient(ds.cfg)
+}
+
+// GetCloudDownloadURL returns the cloud download URL.
+func (ds *DataService) GetCloudDownloadURL() string { return ds.cfg.CloudDownloadURL }
+
+// SetCloudDownloadURL updates the cloud download URL and sync client.
+func (ds *DataService) SetCloudDownloadURL(url string) {
+	ds.cfg.CloudDownloadURL = url
+	ds.syncClient = selectSyncClient(ds.cfg)
+}
+
+// GetCloudToken returns the configured cloud token.
+func (ds *DataService) GetCloudToken() string { return ds.cfg.CloudToken }
+
+// SetCloudToken updates the cloud token and sync client.
+func (ds *DataService) SetCloudToken(tok string) {
+	ds.cfg.CloudToken = tok
+	ds.syncClient = selectSyncClient(ds.cfg)
 }
 
 // Close closes the underlying datastore.

--- a/internal/ui/src/components/SettingsPanel.jsx
+++ b/internal/ui/src/components/SettingsPanel.jsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import {
   Box,
   TextField,
@@ -15,8 +15,21 @@ import {
   SetLogLevel,
   SetLogFormat,
   ExportProjectCSV,
+  GetFormName,
+  SetFormName,
+  GetFormTaxNumber,
+  SetFormTaxNumber,
+  GetFormAddress,
+  SetFormAddress,
+  GetTaxYear,
+  SetTaxYear,
+  GetCloudUploadURL,
+  SetCloudUploadURL,
+  GetCloudDownloadURL,
+  SetCloudDownloadURL,
+  GetCloudToken,
+  SetCloudToken,
 } from "../wailsjs/go/service/DataService";
-import { SetTaxYear } from "../wailsjs/go/pdf/Generator";
 
 export default function SettingsPanel({ projectId }) {
   const { t } = useTranslation();
@@ -26,7 +39,27 @@ export default function SettingsPanel({ projectId }) {
   const [level, setLevel] = useState("info");
   const [format, setFormat] = useState("text");
   const [taxYear, setTaxYear] = useState(2025);
+  const [formName, setFormNameState] = useState("");
+  const [formTaxNumber, setFormTaxNumberState] = useState("");
+  const [formAddress, setFormAddressState] = useState("");
+  const [cloudUploadURL, setCloudUploadURLState] = useState("");
+  const [cloudDownloadURL, setCloudDownloadURLState] = useState("");
+  const [cloudToken, setCloudTokenState] = useState("");
   const [feedback, setFeedback] = useState({ type: "", text: "" });
+
+  useEffect(() => {
+    const load = async () => {
+      setFormNameState((await GetFormName()) || "");
+      setFormTaxNumberState((await GetFormTaxNumber()) || "");
+      setFormAddressState((await GetFormAddress()) || "");
+      const yr = await GetTaxYear();
+      if (yr) setTaxYear(yr);
+      setCloudUploadURLState((await GetCloudUploadURL()) || "");
+      setCloudDownloadURLState((await GetCloudDownloadURL()) || "");
+      setCloudTokenState((await GetCloudToken()) || "");
+    };
+    load();
+  }, []);
 
   const doExport = async () => {
     try {
@@ -67,6 +100,36 @@ export default function SettingsPanel({ projectId }) {
 
   const applyYear = () => {
     SetTaxYear(parseInt(taxYear));
+    setFeedback({ type: "success", text: t("settings.applied") });
+  };
+
+  const applyFormName = () => {
+    SetFormName(formName);
+    setFeedback({ type: "success", text: t("settings.applied") });
+  };
+
+  const applyFormTaxNumber = () => {
+    SetFormTaxNumber(formTaxNumber);
+    setFeedback({ type: "success", text: t("settings.applied") });
+  };
+
+  const applyFormAddress = () => {
+    SetFormAddress(formAddress);
+    setFeedback({ type: "success", text: t("settings.applied") });
+  };
+
+  const applyCloudUploadURL = () => {
+    SetCloudUploadURL(cloudUploadURL);
+    setFeedback({ type: "success", text: t("settings.applied") });
+  };
+
+  const applyCloudDownloadURL = () => {
+    SetCloudDownloadURL(cloudDownloadURL);
+    setFeedback({ type: "success", text: t("settings.applied") });
+  };
+
+  const applyCloudToken = () => {
+    SetCloudToken(cloudToken);
     setFeedback({ type: "success", text: t("settings.applied") });
   };
 
@@ -145,6 +208,72 @@ export default function SettingsPanel({ projectId }) {
           size="small"
         />
         <Button variant="outlined" onClick={applyYear}>
+          {t("settings.apply")}
+        </Button>
+      </Box>
+      <Box sx={{ display: "flex", gap: 2, alignItems: "center" }}>
+        <TextField
+          label={t("settings.form_name")}
+          value={formName}
+          onChange={(e) => setFormNameState(e.target.value)}
+          size="small"
+        />
+        <Button variant="outlined" onClick={applyFormName}>
+          {t("settings.apply")}
+        </Button>
+      </Box>
+      <Box sx={{ display: "flex", gap: 2, alignItems: "center" }}>
+        <TextField
+          label={t("settings.form_tax_number")}
+          value={formTaxNumber}
+          onChange={(e) => setFormTaxNumberState(e.target.value)}
+          size="small"
+        />
+        <Button variant="outlined" onClick={applyFormTaxNumber}>
+          {t("settings.apply")}
+        </Button>
+      </Box>
+      <Box sx={{ display: "flex", gap: 2, alignItems: "center" }}>
+        <TextField
+          label={t("settings.form_address")}
+          value={formAddress}
+          onChange={(e) => setFormAddressState(e.target.value)}
+          size="small"
+        />
+        <Button variant="outlined" onClick={applyFormAddress}>
+          {t("settings.apply")}
+        </Button>
+      </Box>
+      <Box sx={{ display: "flex", gap: 2, alignItems: "center" }}>
+        <TextField
+          label={t("settings.cloud_upload_url")}
+          value={cloudUploadURL}
+          onChange={(e) => setCloudUploadURLState(e.target.value)}
+          size="small"
+        />
+        <Button variant="outlined" onClick={applyCloudUploadURL}>
+          {t("settings.apply")}
+        </Button>
+      </Box>
+      <Box sx={{ display: "flex", gap: 2, alignItems: "center" }}>
+        <TextField
+          label={t("settings.cloud_download_url")}
+          value={cloudDownloadURL}
+          onChange={(e) => setCloudDownloadURLState(e.target.value)}
+          size="small"
+        />
+        <Button variant="outlined" onClick={applyCloudDownloadURL}>
+          {t("settings.apply")}
+        </Button>
+      </Box>
+      <Box sx={{ display: "flex", gap: 2, alignItems: "center" }}>
+        <TextField
+          label={t("settings.cloud_token")}
+          value={cloudToken}
+          onChange={(e) => setCloudTokenState(e.target.value)}
+          size="small"
+        />
+        <Button variant="outlined" onClick={applyCloudToken}>
           {t("settings.apply")}
         </Button>
       </Box>

--- a/internal/ui/src/components/SettingsPanel.test.jsx
+++ b/internal/ui/src/components/SettingsPanel.test.jsx
@@ -10,10 +10,20 @@ vi.mock('../wailsjs/go/service/DataService', () => ({
   SetLogLevel: vi.fn(),
   SetLogFormat: vi.fn(),
   ExportProjectCSV: vi.fn(),
-}), { virtual: true });
-
-vi.mock('../wailsjs/go/pdf/Generator', () => ({
+  GetFormName: vi.fn().mockResolvedValue('Club'),
+  SetFormName: vi.fn(),
+  GetFormTaxNumber: vi.fn().mockResolvedValue('11/111/11111'),
+  SetFormTaxNumber: vi.fn(),
+  GetFormAddress: vi.fn().mockResolvedValue('Street'),
+  SetFormAddress: vi.fn(),
+  GetTaxYear: vi.fn().mockResolvedValue(2025),
   SetTaxYear: vi.fn(),
+  GetCloudUploadURL: vi.fn().mockResolvedValue('u'),
+  SetCloudUploadURL: vi.fn(),
+  GetCloudDownloadURL: vi.fn().mockResolvedValue('d'),
+  SetCloudDownloadURL: vi.fn(),
+  GetCloudToken: vi.fn().mockResolvedValue('t'),
+  SetCloudToken: vi.fn(),
 }), { virtual: true });
 
 beforeEach(() => {
@@ -25,4 +35,21 @@ test('shows success message when log format applied', async () => {
   const applyButtons = screen.getAllByRole('button', { name: /Anwenden/i });
   fireEvent.click(applyButtons[1]);
   expect(await screen.findByText('settings.applied')).toBeInTheDocument();
+});
+
+test('loads settings from service', async () => {
+  render(<SettingsPanel projectId={1} />);
+  expect(await screen.findByDisplayValue('Club')).toBeInTheDocument();
+  expect(await screen.findByDisplayValue('11/111/11111')).toBeInTheDocument();
+  expect(await screen.findByDisplayValue('Street')).toBeInTheDocument();
+});
+
+test('applies form name change', async () => {
+  const { SetFormName } = await import('../wailsjs/go/service/DataService');
+  render(<SettingsPanel projectId={1} />);
+  const input = await screen.findByLabelText(/Vereinsname/i);
+  fireEvent.change(input, { target: { value: 'New' } });
+  const buttons = screen.getAllByRole('button', { name: /Anwenden/i });
+  fireEvent.click(buttons[3]);
+  expect(SetFormName).toHaveBeenCalledWith('New');
 });

--- a/internal/ui/src/locales/de.json
+++ b/internal/ui/src/locales/de.json
@@ -22,7 +22,13 @@
     "exported": "Datenbank exportiert",
     "restored": "Datenbank wiederhergestellt",
     "csv_exported": "CSV exportiert",
-    "tax_year": "Steuerjahr"
+    "tax_year": "Steuerjahr",
+    "form_name": "Vereinsname",
+    "form_tax_number": "Steuernummer",
+    "form_address": "Adresse",
+    "cloud_upload_url": "Cloud Upload URL",
+    "cloud_download_url": "Cloud Download URL",
+    "cloud_token": "Cloud Token"
   },
   "income": {
     "new": "Neue Einnahme",

--- a/internal/ui/src/locales/en.json
+++ b/internal/ui/src/locales/en.json
@@ -22,7 +22,13 @@
     "exported": "Database exported",
     "restored": "Database restored",
     "csv_exported": "CSV exported",
-    "tax_year": "Tax Year"
+    "tax_year": "Tax Year",
+    "form_name": "Organization Name",
+    "form_tax_number": "Tax Number",
+    "form_address": "Address",
+    "cloud_upload_url": "Cloud Upload URL",
+    "cloud_download_url": "Cloud Download URL",
+    "cloud_token": "Cloud Token"
   },
   "income": {
     "new": "New Income",

--- a/internal/ui/src/wailsjs/go/service/DataService.js
+++ b/internal/ui/src/wailsjs/go/service/DataService.js
@@ -97,3 +97,59 @@ export function ExportProjectCSV(arg1, arg2) {
 export function GenerateStatistics(arg1, arg2) {
   return window.go.service.DataService.GenerateStatistics(arg1, arg2);
 }
+
+export function GetFormName() {
+  return window.go.service.DataService.GetFormName();
+}
+
+export function SetFormName(arg1) {
+  return window.go.service.DataService.SetFormName(arg1);
+}
+
+export function GetFormTaxNumber() {
+  return window.go.service.DataService.GetFormTaxNumber();
+}
+
+export function SetFormTaxNumber(arg1) {
+  return window.go.service.DataService.SetFormTaxNumber(arg1);
+}
+
+export function GetFormAddress() {
+  return window.go.service.DataService.GetFormAddress();
+}
+
+export function SetFormAddress(arg1) {
+  return window.go.service.DataService.SetFormAddress(arg1);
+}
+
+export function GetTaxYear() {
+  return window.go.service.DataService.GetTaxYear();
+}
+
+export function SetTaxYear(arg1) {
+  return window.go.service.DataService.SetTaxYear(arg1);
+}
+
+export function GetCloudUploadURL() {
+  return window.go.service.DataService.GetCloudUploadURL();
+}
+
+export function SetCloudUploadURL(arg1) {
+  return window.go.service.DataService.SetCloudUploadURL(arg1);
+}
+
+export function GetCloudDownloadURL() {
+  return window.go.service.DataService.GetCloudDownloadURL();
+}
+
+export function SetCloudDownloadURL(arg1) {
+  return window.go.service.DataService.SetCloudDownloadURL(arg1);
+}
+
+export function GetCloudToken() {
+  return window.go.service.DataService.GetCloudToken();
+}
+
+export function SetCloudToken(arg1) {
+  return window.go.service.DataService.SetCloudToken(arg1);
+}


### PR DESCRIPTION
## Summary
- store config in `DataService` and add getters/setters
- expose new Wails JS bindings for settings
- extend React `SettingsPanel` with fields for form and cloud settings
- provide i18n strings for new settings fields
- test loading and applying settings via Vitest

## Testing
- `npm test --prefix internal/ui`
- `(cd cmd && go test ./...)`
- `(cd internal && go test ./...)`


------
https://chatgpt.com/codex/tasks/task_e_686a5322e4b88333a77a44eb4875572d