### PR TITLE
Dokumentation der PDF-Vorlagen und Fallback

### DIFF
--- a/docs/DOCUMENTATION.md
+++ b/docs/DOCUMENTATION.md
@@ -62,6 +62,9 @@ Pfade wie `dbPath` oder `pdfDir` k\xC3\xB6nnen in dieser Datei angepasst werden.
    - Mitglieder verwalten
    - \"Bericht erstellen\" w\xC3\xA4hlen, um PDF-Formulare zu generieren
    - Optional CSV-Exporte oder Datenbank-Backups ausf\xC3\xBChren
+5. Die offiziellen Formularvorlagen separat herunterladen und in
+   `internal/pdf/templates/` ablegen. Ohne diese Dateien zeigt das Programm
+   einen Hinweis in den erzeugten PDFs.
 
 ## Installing Dependencies
 

--- a/docs/Todo-fuer-User.md
+++ b/docs/Todo-fuer-User.md
@@ -11,6 +11,14 @@ So bleiben die Versionskontrolle und der Repository-Umfang schlank, während tro
 
 ## Offizielle Formulare einbinden
 
-Im Verzeichnis `internal/pdf/templates` befinden sich nur Platzhalterdateien. Um die amtlichen PDF-Formulare zu verwenden, kopieren Sie die Originale mit dem gleichen Dateinamen (z. B. `kst1.pdf`) in dieses Verzeichnis. Beim Erzeugen der Formulare greift der Generator automatisch auf diese Vorlagen zurück.
+Im Verzeichnis `internal/pdf/templates` befinden sich lediglich Platzhalterdateien. 
+Laden Sie daher die amtlichen PDF-Formulare von der Finanzverwaltung oder aus ELSTER
+herunter und speichern Sie sie **lokal** unter dem gleichen Dateinamen in diesem
+Ordner. Die Dateinamen müssen exakt den Platzhaltern entsprechen (z. B. `kst1.pdf`).
+Beim Erzeugen der Formulare greift der Generator automatisch auf diese Vorlagen
+zurück, sofern sie vorhanden sind.
 
-**Hinweis:** Die fertigen PDF-Vordrucke `kst1.pdf`, `kst1f.pdf`, `anlage_gem.pdf`, `anlage_gk.pdf` und `anlage_sport.pdf` gehören ebenfalls in dieses Verzeichnis.
+**Hinweis:** Aus Lizenzgründen dürfen die Original-PDFs nicht ins Repository
+eingecheckt werden. Legen Sie die Dateien `kst1.pdf`, `kst1f.pdf`,
+`anlage_gem.pdf`, `anlage_gk.pdf` und `anlage_sport.pdf` daher manuell in
+`internal/pdf/templates/` ab und schließen Sie sie von einem Commit aus.

--- a/internal/pdf/pdf.go
+++ b/internal/pdf/pdf.go
@@ -30,9 +30,15 @@ func addTemplate(pdf *gofpdf.Fpdf, name string) {
 		imp.UseImportedTemplate(pdf, tpl, 0, 0, 210, 297)
 		return
 	}
+	pdf.SetFont("Arial", "", 8)
+	pdf.SetTextColor(200, 0, 0)
+	pdf.MultiCell(0, 4,
+		fmt.Sprintf("Vorlage %s.pdf nicht gefunden. Bitte Original in %s ablegen.", name, templatesDir),
+		"", "L", false)
+	pdf.SetTextColor(0, 0, 0)
 	metaPath := filepath.Join(templatesDir, name+".txt")
 	if b, err := os.ReadFile(metaPath); err == nil {
-		pdf.SetFont("Arial", "", 8)
+		pdf.Ln(2)
 		pdf.MultiCell(0, 4, string(b), "", "L", false)
 		pdf.Ln(4)
 	}


### PR DESCRIPTION
## Summary
- beschreibe das Ablegen der offiziellen PDF-Formulare im User Guide
- ergaenze den Schnellstart um den Hinweis auf die manuelle Bereitstellung
- zeige im PDF einen Hinweis, wenn keine Vorlage gefunden wurde

## Testing
- `go test ./cmd/... ./internal/... ./internal/pdf/...`


------
https://chatgpt.com/codex/tasks/task_e_686a66d1b2688333a1e379650a035889