### PR TITLE
Add additional form fields

### DIFF
--- a/config.example.json
+++ b/config.example.json
@@ -4,6 +4,9 @@
   "logFile": "baristeuer.log",
   "logLevel": "info",
   "logFormat": "text",
+  "formCity": "",
+  "formBankAccount": "",
+  "formRepresentative": "",
   "cloudUploadURL": "",
   "cloudDownloadURL": "",
   "cloudToken": ""

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -12,30 +12,36 @@ const DefaultPDFDir = "internal/data/reports"
 
 // Config holds application configuration values.
 type Config struct {
-	DBPath           string `json:"dbPath"`
-	PDFDir           string `json:"pdfDir"`
-	LogFile          string `json:"logFile"`
-	LogLevel         string `json:"logLevel"`
-	LogFormat        string `json:"logFormat"`
-	TaxYear          int    `json:"taxYear"`
-	FormName         string `json:"formName"`
-	FormTaxNumber    string `json:"formTaxNumber"`
-	FormAddress      string `json:"formAddress"`
-	CloudUploadURL   string `json:"cloudUploadURL"`
-	CloudDownloadURL string `json:"cloudDownloadURL"`
-	CloudToken       string `json:"cloudToken"`
+	DBPath             string `json:"dbPath"`
+	PDFDir             string `json:"pdfDir"`
+	LogFile            string `json:"logFile"`
+	LogLevel           string `json:"logLevel"`
+	LogFormat          string `json:"logFormat"`
+	TaxYear            int    `json:"taxYear"`
+	FormName           string `json:"formName"`
+	FormTaxNumber      string `json:"formTaxNumber"`
+	FormAddress        string `json:"formAddress"`
+	FormCity           string `json:"formCity"`
+	FormBankAccount    string `json:"formBankAccount"`
+	FormRepresentative string `json:"formRepresentative"`
+	CloudUploadURL     string `json:"cloudUploadURL"`
+	CloudDownloadURL   string `json:"cloudDownloadURL"`
+	CloudToken         string `json:"cloudToken"`
 }
 
 // DefaultConfig provides sensible defaults for a new configuration file.
 var DefaultConfig = Config{
-	DBPath:           "baristeuer.db",
-	PDFDir:           filepath.Join(".", DefaultPDFDir),
-	LogFile:          "baristeuer.log",
-	LogLevel:         "info",
-	LogFormat:        "text",
-	CloudUploadURL:   "",
-	CloudDownloadURL: "",
-	CloudToken:       "",
+	DBPath:             "baristeuer.db",
+	PDFDir:             filepath.Join(".", DefaultPDFDir),
+	LogFile:            "baristeuer.log",
+	LogLevel:           "info",
+	LogFormat:          "text",
+	FormCity:           "",
+	FormBankAccount:    "",
+	FormRepresentative: "",
+	CloudUploadURL:     "",
+	CloudDownloadURL:   "",
+	CloudToken:         "",
 }
 
 // Load reads configuration from the given file path. If the file does not exist,

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -19,7 +19,10 @@ func TestLoadFromFile(t *testing.T) {
         "taxYear": 2026,
         "formName": "Club",
         "formTaxNumber": "11/111/11111",
-        "formAddress": "Street 1"
+        "formAddress": "Street 1",
+        "formCity": "Town",
+        "formBankAccount": "DE123",
+        "formRepresentative": "Alice"
     }`
 	if err := os.WriteFile(path, []byte(data), 0o644); err != nil {
 		t.Fatal(err)
@@ -31,6 +34,7 @@ func TestLoadFromFile(t *testing.T) {
 	}
 	if cfg.DBPath != "db.sqlite" || cfg.PDFDir != "./pdfs" || cfg.LogFile != "app.log" || cfg.LogLevel != "debug" || cfg.LogFormat != "json" ||
 		cfg.TaxYear != 2026 || cfg.FormName != "Club" || cfg.FormTaxNumber != "11/111/11111" || cfg.FormAddress != "Street 1" ||
+		cfg.FormCity != "Town" || cfg.FormBankAccount != "DE123" || cfg.FormRepresentative != "Alice" ||
 		cfg.CloudUploadURL != "" || cfg.CloudDownloadURL != "" || cfg.CloudToken != "" {
 		t.Fatalf("unexpected config: %+v", cfg)
 	}
@@ -55,7 +59,9 @@ func TestLoadMissingFile(t *testing.T) {
 func TestSaveAndVerify(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "out.json")
-	expected := Config{DBPath: "db", PDFDir: "pdf", LogFile: "log", LogLevel: "info", LogFormat: "json", TaxYear: 2025, FormName: "Org", FormTaxNumber: "12/222/22222", FormAddress: "Main"}
+	expected := Config{DBPath: "db", PDFDir: "pdf", LogFile: "log", LogLevel: "info", LogFormat: "json", TaxYear: 2025,
+		FormName: "Org", FormTaxNumber: "12/222/22222", FormAddress: "Main",
+		FormCity: "City", FormBankAccount: "DE000", FormRepresentative: "Rep"}
 	expected.CloudUploadURL = ""
 	expected.CloudDownloadURL = ""
 	expected.CloudToken = ""

--- a/internal/pdf/pdf.go
+++ b/internal/pdf/pdf.go
@@ -47,13 +47,14 @@ type Generator struct {
 
 // FormInfo contains data to fill the various tax forms.
 type FormInfo struct {
-	Name        string
-	TaxNumber   string
-	Address     string
-	City        string
-	BankAccount string
-	Activity    string
-	FiscalYear  string
+	Name           string
+	TaxNumber      string
+	Address        string
+	City           string
+	BankAccount    string
+	Representative string
+	Activity       string
+	FiscalYear     string
 }
 
 // Validate checks if the required fields are set and values are plausible.
@@ -66,6 +67,15 @@ func (f FormInfo) Validate() error {
 	}
 	if f.Address == "" {
 		return fmt.Errorf("address is required")
+	}
+	if f.City == "" {
+		return fmt.Errorf("city is required")
+	}
+	if f.BankAccount == "" {
+		return fmt.Errorf("bank account is required")
+	}
+	if f.Representative == "" {
+		return fmt.Errorf("representative is required")
 	}
 	if f.FiscalYear != "" {
 		year, err := strconv.Atoi(f.FiscalYear)
@@ -100,10 +110,13 @@ func (g *Generator) SetTaxYear(year int) {
 
 func (g *Generator) formInfo() FormInfo {
 	return FormInfo{
-		Name:       g.cfg.FormName,
-		TaxNumber:  g.cfg.FormTaxNumber,
-		Address:    g.cfg.FormAddress,
-		FiscalYear: fmt.Sprintf("%d", g.cfg.TaxYear),
+		Name:           g.cfg.FormName,
+		TaxNumber:      g.cfg.FormTaxNumber,
+		Address:        g.cfg.FormAddress,
+		City:           g.cfg.FormCity,
+		BankAccount:    g.cfg.FormBankAccount,
+		Representative: g.cfg.FormRepresentative,
+		FiscalYear:     fmt.Sprintf("%d", g.cfg.TaxYear),
 	}
 }
 
@@ -375,7 +388,7 @@ func (g *Generator) GenerateKSt1(ctx context.Context, projectID int64) (string, 
 	tableRow(pdf, widths, []string{"Straße, Hausnummer", info.Address})
 	tableRow(pdf, widths, []string{"PLZ, Ort", info.City})
 	tableRow(pdf, widths, []string{"Bankverbindung", info.BankAccount})
-	tableRow(pdf, widths, []string{"Vertreten durch", ""})
+	tableRow(pdf, widths, []string{"Vertreten durch", info.Representative})
 	tableRow(pdf, widths, []string{"Veranlagungszeitraum", info.FiscalYear})
 	pdf.Ln(6)
 
@@ -475,7 +488,7 @@ func (g *Generator) GenerateAnlageGem(ctx context.Context, projectID int64) (str
 	pdf.Ln(8)
 	tableHeader(pdf, widths, []string{"Angabe", "Wert"})
 	tableRow(pdf, widths, []string{"Steuerbeg\xC3\xBCnstigte Zwecke", ""})
-	tableRow(pdf, widths, []string{"Vertreten durch", ""})
+	tableRow(pdf, widths, []string{"Vertreten durch", info.Representative})
 	tableRow(pdf, widths, []string{"Verwendung der Mittel", ""})
 	tableRow(pdf, widths, []string{"Mitglieder", fmt.Sprintf("%d", memberCount)})
 	tableRow(pdf, widths, []string{"Einnahmen", fmt.Sprintf("%.2f EUR", revenue)})

--- a/internal/pdf/pdf_test.go
+++ b/internal/pdf/pdf_test.go
@@ -132,7 +132,8 @@ func TestFormGeneration(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	cfg := config.Config{TaxYear: 2026, FormName: "Testverein", FormTaxNumber: "11/111/11111", FormAddress: "Hauptstr. 1"}
+	cfg := config.Config{TaxYear: 2026, FormName: "Testverein", FormTaxNumber: "11/111/11111", FormAddress: "Hauptstr. 1",
+		FormCity: "Town", FormBankAccount: "DE123", FormRepresentative: "Alice"}
 	g := NewGenerator(dir, store, &cfg)
 
 	files := []struct {
@@ -254,5 +255,33 @@ func TestGenerateReportCombinations(t *testing.T) {
 				t.Fatalf("file still exists: %v", err)
 			}
 		})
+	}
+}
+
+func TestFormInfoValidate(t *testing.T) {
+	valid := FormInfo{
+		Name:           "Org",
+		TaxNumber:      "1",
+		Address:        "Street",
+		City:           "Town",
+		BankAccount:    "DE123",
+		Representative: "Alice",
+		FiscalYear:     "2025",
+	}
+	if err := valid.Validate(); err != nil {
+		t.Fatalf("valid info failed: %v", err)
+	}
+	cases := []FormInfo{
+		{TaxNumber: "1", Address: "Street", City: "Town", BankAccount: "DE123", Representative: "A"},
+		{Name: "n", Address: "Street", City: "Town", BankAccount: "DE123", Representative: "A"},
+		{Name: "n", TaxNumber: "1", City: "Town", BankAccount: "DE123", Representative: "A"},
+		{Name: "n", TaxNumber: "1", Address: "Street", BankAccount: "DE123", Representative: "A"},
+		{Name: "n", TaxNumber: "1", Address: "Street", City: "Town", Representative: "A"},
+		{Name: "n", TaxNumber: "1", Address: "Street", City: "Town", BankAccount: "DE123"},
+	}
+	for i, c := range cases {
+		if err := c.Validate(); err == nil {
+			t.Fatalf("case %d expected error", i)
+		}
 	}
 }

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -430,6 +430,24 @@ func (ds *DataService) GetFormAddress() string { return ds.cfg.FormAddress }
 // SetFormAddress updates the configured form address.
 func (ds *DataService) SetFormAddress(addr string) { ds.cfg.FormAddress = addr }
 
+// GetFormCity returns the configured form city.
+func (ds *DataService) GetFormCity() string { return ds.cfg.FormCity }
+
+// SetFormCity updates the configured form city.
+func (ds *DataService) SetFormCity(city string) { ds.cfg.FormCity = city }
+
+// GetFormBankAccount returns the configured bank account.
+func (ds *DataService) GetFormBankAccount() string { return ds.cfg.FormBankAccount }
+
+// SetFormBankAccount updates the bank account.
+func (ds *DataService) SetFormBankAccount(acc string) { ds.cfg.FormBankAccount = acc }
+
+// GetFormRepresentative returns the representative name.
+func (ds *DataService) GetFormRepresentative() string { return ds.cfg.FormRepresentative }
+
+// SetFormRepresentative updates the representative name.
+func (ds *DataService) SetFormRepresentative(rep string) { ds.cfg.FormRepresentative = rep }
+
 // GetTaxYear returns the current tax year.
 func (ds *DataService) GetTaxYear() int { return ds.cfg.TaxYear }
 

--- a/internal/service/service_test.go
+++ b/internal/service/service_test.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"baristeuer/internal/config"
 	"bytes"
 	"context"
 	"errors"
@@ -523,6 +524,26 @@ func TestDataService_ExportProjectCSV(t *testing.T) {
 	}
 	if !strings.Contains(string(data), "income") || !strings.Contains(string(data), "expense") {
 		t.Fatalf("csv content unexpected: %s", data)
+	}
+}
+
+func TestFormFieldGettersSetters(t *testing.T) {
+	ds, err := NewDataService(":memory:", nil, nil, &config.Config{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ds.Close()
+	ds.SetFormCity("Town")
+	if ds.GetFormCity() != "Town" {
+		t.Fatalf("city getter/setter failed")
+	}
+	ds.SetFormBankAccount("DE123")
+	if ds.GetFormBankAccount() != "DE123" {
+		t.Fatalf("bank account getter/setter failed")
+	}
+	ds.SetFormRepresentative("Alice")
+	if ds.GetFormRepresentative() != "Alice" {
+		t.Fatalf("representative getter/setter failed")
 	}
 }
 

--- a/internal/ui/src/components/SettingsPanel.jsx
+++ b/internal/ui/src/components/SettingsPanel.jsx
@@ -21,6 +21,12 @@ import {
   SetFormTaxNumber,
   GetFormAddress,
   SetFormAddress,
+  GetFormCity,
+  SetFormCity,
+  GetFormBankAccount,
+  SetFormBankAccount,
+  GetFormRepresentative,
+  SetFormRepresentative,
   GetTaxYear,
   SetTaxYear,
   GetCloudUploadURL,
@@ -42,6 +48,9 @@ export default function SettingsPanel({ projectId }) {
   const [formName, setFormNameState] = useState("");
   const [formTaxNumber, setFormTaxNumberState] = useState("");
   const [formAddress, setFormAddressState] = useState("");
+  const [formCity, setFormCityState] = useState("");
+  const [formBankAccount, setFormBankAccountState] = useState("");
+  const [formRepresentative, setFormRepresentativeState] = useState("");
   const [cloudUploadURL, setCloudUploadURLState] = useState("");
   const [cloudDownloadURL, setCloudDownloadURLState] = useState("");
   const [cloudToken, setCloudTokenState] = useState("");
@@ -52,6 +61,9 @@ export default function SettingsPanel({ projectId }) {
       setFormNameState((await GetFormName()) || "");
       setFormTaxNumberState((await GetFormTaxNumber()) || "");
       setFormAddressState((await GetFormAddress()) || "");
+      setFormCityState((await GetFormCity()) || "");
+      setFormBankAccountState((await GetFormBankAccount()) || "");
+      setFormRepresentativeState((await GetFormRepresentative()) || "");
       const yr = await GetTaxYear();
       if (yr) setTaxYear(yr);
       setCloudUploadURLState((await GetCloudUploadURL()) || "");
@@ -115,6 +127,21 @@ export default function SettingsPanel({ projectId }) {
 
   const applyFormAddress = () => {
     SetFormAddress(formAddress);
+    setFeedback({ type: "success", text: t("settings.applied") });
+  };
+
+  const applyFormCity = () => {
+    SetFormCity(formCity);
+    setFeedback({ type: "success", text: t("settings.applied") });
+  };
+
+  const applyFormBankAccount = () => {
+    SetFormBankAccount(formBankAccount);
+    setFeedback({ type: "success", text: t("settings.applied") });
+  };
+
+  const applyFormRepresentative = () => {
+    SetFormRepresentative(formRepresentative);
     setFeedback({ type: "success", text: t("settings.applied") });
   };
 
@@ -241,6 +268,39 @@ export default function SettingsPanel({ projectId }) {
           size="small"
         />
         <Button variant="outlined" onClick={applyFormAddress}>
+          {t("settings.apply")}
+        </Button>
+      </Box>
+      <Box sx={{ display: "flex", gap: 2, alignItems: "center" }}>
+        <TextField
+          label={t("settings.form_city")}
+          value={formCity}
+          onChange={(e) => setFormCityState(e.target.value)}
+          size="small"
+        />
+        <Button variant="outlined" onClick={applyFormCity}>
+          {t("settings.apply")}
+        </Button>
+      </Box>
+      <Box sx={{ display: "flex", gap: 2, alignItems: "center" }}>
+        <TextField
+          label={t("settings.form_bank_account")}
+          value={formBankAccount}
+          onChange={(e) => setFormBankAccountState(e.target.value)}
+          size="small"
+        />
+        <Button variant="outlined" onClick={applyFormBankAccount}>
+          {t("settings.apply")}
+        </Button>
+      </Box>
+      <Box sx={{ display: "flex", gap: 2, alignItems: "center" }}>
+        <TextField
+          label={t("settings.form_representative")}
+          value={formRepresentative}
+          onChange={(e) => setFormRepresentativeState(e.target.value)}
+          size="small"
+        />
+        <Button variant="outlined" onClick={applyFormRepresentative}>
           {t("settings.apply")}
         </Button>
       </Box>

--- a/internal/ui/src/components/SettingsPanel.test.jsx
+++ b/internal/ui/src/components/SettingsPanel.test.jsx
@@ -1,55 +1,68 @@
-import { render, screen, fireEvent } from '@testing-library/react';
-import '@testing-library/jest-dom';
-import { vi, beforeEach } from 'vitest';
-import SettingsPanel from './SettingsPanel';
-import '../i18n';
+import { render, screen, fireEvent } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import { vi, beforeEach } from "vitest";
+import SettingsPanel from "./SettingsPanel";
+import "../i18n";
 
-vi.mock('../wailsjs/go/service/DataService', () => ({
-  ExportDatabase: vi.fn(),
-  RestoreDatabase: vi.fn(),
-  SetLogLevel: vi.fn(),
-  SetLogFormat: vi.fn(),
-  ExportProjectCSV: vi.fn(),
-  GetFormName: vi.fn().mockResolvedValue('Club'),
-  SetFormName: vi.fn(),
-  GetFormTaxNumber: vi.fn().mockResolvedValue('11/111/11111'),
-  SetFormTaxNumber: vi.fn(),
-  GetFormAddress: vi.fn().mockResolvedValue('Street'),
-  SetFormAddress: vi.fn(),
-  GetTaxYear: vi.fn().mockResolvedValue(2025),
-  SetTaxYear: vi.fn(),
-  GetCloudUploadURL: vi.fn().mockResolvedValue('u'),
-  SetCloudUploadURL: vi.fn(),
-  GetCloudDownloadURL: vi.fn().mockResolvedValue('d'),
-  SetCloudDownloadURL: vi.fn(),
-  GetCloudToken: vi.fn().mockResolvedValue('t'),
-  SetCloudToken: vi.fn(),
-}), { virtual: true });
+vi.mock(
+  "../wailsjs/go/service/DataService",
+  () => ({
+    ExportDatabase: vi.fn(),
+    RestoreDatabase: vi.fn(),
+    SetLogLevel: vi.fn(),
+    SetLogFormat: vi.fn(),
+    ExportProjectCSV: vi.fn(),
+    GetFormName: vi.fn().mockResolvedValue("Club"),
+    SetFormName: vi.fn(),
+    GetFormTaxNumber: vi.fn().mockResolvedValue("11/111/11111"),
+    SetFormTaxNumber: vi.fn(),
+    GetFormAddress: vi.fn().mockResolvedValue("Street"),
+    SetFormAddress: vi.fn(),
+    GetFormCity: vi.fn().mockResolvedValue("Town"),
+    SetFormCity: vi.fn(),
+    GetFormBankAccount: vi.fn().mockResolvedValue("DE123"),
+    SetFormBankAccount: vi.fn(),
+    GetFormRepresentative: vi.fn().mockResolvedValue("Alice"),
+    SetFormRepresentative: vi.fn(),
+    GetTaxYear: vi.fn().mockResolvedValue(2025),
+    SetTaxYear: vi.fn(),
+    GetCloudUploadURL: vi.fn().mockResolvedValue("u"),
+    SetCloudUploadURL: vi.fn(),
+    GetCloudDownloadURL: vi.fn().mockResolvedValue("d"),
+    SetCloudDownloadURL: vi.fn(),
+    GetCloudToken: vi.fn().mockResolvedValue("t"),
+    SetCloudToken: vi.fn(),
+  }),
+  { virtual: true },
+);
 
 beforeEach(() => {
   vi.clearAllMocks();
 });
 
-test('shows success message when log format applied', async () => {
+test("shows success message when log format applied", async () => {
   render(<SettingsPanel projectId={1} />);
-  const applyButtons = screen.getAllByRole('button', { name: /Anwenden/i });
+  const applyButtons = screen.getAllByRole("button", { name: /Anwenden/i });
   fireEvent.click(applyButtons[1]);
-  expect(await screen.findByText('settings.applied')).toBeInTheDocument();
+  expect(await screen.findByText("settings.applied")).toBeInTheDocument();
 });
 
-test('loads settings from service', async () => {
+test("loads settings from service", async () => {
   render(<SettingsPanel projectId={1} />);
-  expect(await screen.findByDisplayValue('Club')).toBeInTheDocument();
-  expect(await screen.findByDisplayValue('11/111/11111')).toBeInTheDocument();
-  expect(await screen.findByDisplayValue('Street')).toBeInTheDocument();
+  expect(await screen.findByDisplayValue("Club")).toBeInTheDocument();
+  expect(await screen.findByDisplayValue("11/111/11111")).toBeInTheDocument();
+  expect(await screen.findByDisplayValue("Street")).toBeInTheDocument();
+  expect(await screen.findByDisplayValue("Town")).toBeInTheDocument();
+  expect(await screen.findByDisplayValue("DE123")).toBeInTheDocument();
+  expect(await screen.findByDisplayValue("Alice")).toBeInTheDocument();
 });
 
-test('applies form name change', async () => {
-  const { SetFormName } = await import('../wailsjs/go/service/DataService');
+test("applies form name change", async () => {
+  const { SetFormName } = await import("../wailsjs/go/service/DataService");
   render(<SettingsPanel projectId={1} />);
   const input = await screen.findByLabelText(/Vereinsname/i);
-  fireEvent.change(input, { target: { value: 'New' } });
-  const buttons = screen.getAllByRole('button', { name: /Anwenden/i });
+  fireEvent.change(input, { target: { value: "New" } });
+  const buttons = screen.getAllByRole("button", { name: /Anwenden/i });
   fireEvent.click(buttons[3]);
-  expect(SetFormName).toHaveBeenCalledWith('New');
+  expect(SetFormName).toHaveBeenCalledWith("New");
 });

--- a/internal/ui/src/locales/de.json
+++ b/internal/ui/src/locales/de.json
@@ -26,6 +26,9 @@
     "form_name": "Vereinsname",
     "form_tax_number": "Steuernummer",
     "form_address": "Adresse",
+    "form_city": "Ort",
+    "form_bank_account": "Bankverbindung",
+    "form_representative": "Vertretungsberechtigter",
     "cloud_upload_url": "Cloud Upload URL",
     "cloud_download_url": "Cloud Download URL",
     "cloud_token": "Cloud Token"

--- a/internal/ui/src/locales/en.json
+++ b/internal/ui/src/locales/en.json
@@ -26,6 +26,9 @@
     "form_name": "Organization Name",
     "form_tax_number": "Tax Number",
     "form_address": "Address",
+    "form_city": "City",
+    "form_bank_account": "Bank Account",
+    "form_representative": "Representative",
     "cloud_upload_url": "Cloud Upload URL",
     "cloud_download_url": "Cloud Download URL",
     "cloud_token": "Cloud Token"

--- a/internal/ui/src/wailsjs/go/service/DataService.js
+++ b/internal/ui/src/wailsjs/go/service/DataService.js
@@ -122,6 +122,30 @@ export function SetFormAddress(arg1) {
   return window.go.service.DataService.SetFormAddress(arg1);
 }
 
+export function GetFormCity() {
+  return window.go.service.DataService.GetFormCity();
+}
+
+export function SetFormCity(arg1) {
+  return window.go.service.DataService.SetFormCity(arg1);
+}
+
+export function GetFormBankAccount() {
+  return window.go.service.DataService.GetFormBankAccount();
+}
+
+export function SetFormBankAccount(arg1) {
+  return window.go.service.DataService.SetFormBankAccount(arg1);
+}
+
+export function GetFormRepresentative() {
+  return window.go.service.DataService.GetFormRepresentative();
+}
+
+export function SetFormRepresentative(arg1) {
+  return window.go.service.DataService.SetFormRepresentative(arg1);
+}
+
 export function GetTaxYear() {
   return window.go.service.DataService.GetTaxYear();
 }


### PR DESCRIPTION
## Summary
- extend Config with city, bank account and representative fields
- populate new form fields in pdf generator
- add React controls for the new settings with translations
- update example config and generated JS
- unit tests for validation and getter/setter behaviour

## Testing
- `go test ./cmd/... ./internal/... ./internal/pdf/... ./internal/report/...`
- `npm ci`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686a66d1ebe8833386da11bf242c77b6