### PR TITLE
Add PDF preview component

### DIFF
--- a/internal/ui/e2e/forms.spec.js
+++ b/internal/ui/e2e/forms.spec.js
@@ -17,6 +17,8 @@ test("generate forms", async ({ page }) => {
   await page.getByRole("tab", { name: /Formulare/i }).click();
   await page.getByRole("button", { name: /Alle Formulare erstellen/i }).click();
 
+  await expect(page.getByTitle("PDF Preview")).toBeVisible();
+
   const calls = await page.evaluate(() => window.__pdfCalls);
   expect(calls.map((c) => c.name)).toContain("GenerateAllForms");
 });

--- a/internal/ui/src/App.jsx
+++ b/internal/ui/src/App.jsx
@@ -16,6 +16,7 @@ import FormsPanel from "./components/FormsPanel";
 import SettingsPanel from "./components/SettingsPanel";
 import ReportPanel from "./components/ReportPanel";
 import StatisticsChart from "./components/StatisticsChart";
+import PDFPreview from "./components/PDFPreview";
 
 export default function App() {
   const [incomes, setIncomes] = useState([]);
@@ -32,6 +33,7 @@ export default function App() {
   const [incomeError, setIncomeError] = useState("");
   const [expenseError, setExpenseError] = useState("");
   const [memberError, setMemberError] = useState("");
+  const [previewPath, setPreviewPath] = useState("");
   const handleError = (err, setter, key = 'errors.add') => {
     setter(err.message || t(key));
   };
@@ -214,7 +216,12 @@ export default function App() {
             </Paper>
           </>
         )}
-        {tab === 4 && <FormsPanel projectId={projectId} />}
+        {tab === 4 && (
+          <>
+            <FormsPanel projectId={projectId} onGenerated={setPreviewPath} />
+            <PDFPreview filePath={previewPath} />
+          </>
+        )}
         {tab === 5 && (
           <Paper sx={{ p: 3 }}>
             <TaxPanel projectId={projectId} />
@@ -222,8 +229,9 @@ export default function App() {
         )}
         {tab === 6 && (
           <Paper sx={{ p: 3 }}>
-            <ReportPanel projectId={projectId} />
+            <ReportPanel projectId={projectId} onGenerated={setPreviewPath} />
             <StatisticsChart projectId={projectId} />
+            <PDFPreview filePath={previewPath} />
           </Paper>
         )}
         {tab === 7 && (

--- a/internal/ui/src/components/FormsPanel.jsx
+++ b/internal/ui/src/components/FormsPanel.jsx
@@ -19,13 +19,16 @@ import {
   GenerateKSt1F,
 } from "../wailsjs/go/pdf/Generator";
 
-export default function FormsPanel({ projectId }) {
+
+export default function FormsPanel({ projectId, onGenerated }) {
   const [error, setError] = useState("");
   const { t } = useTranslation();
 
   const handleGenerate = async (fn) => {
     try {
-      await fn(projectId);
+      const result = await fn(projectId);
+      const path = Array.isArray(result) ? result[result.length - 1] : result;
+      onGenerated && onGenerated(path);
     } catch (err) {
       setError(err.message || t('forms.error'));
     }

--- a/internal/ui/src/components/PDFPreview.jsx
+++ b/internal/ui/src/components/PDFPreview.jsx
@@ -1,0 +1,21 @@
+import { Box, Typography } from "@mui/material";
+import { useTranslation } from "react-i18next";
+
+export default function PDFPreview({ filePath }) {
+  const { t } = useTranslation();
+  if (!filePath) {
+    return <Typography>{t('preview.none') || 'No PDF generated yet'}</Typography>;
+  }
+  return (
+    <Box sx={{ mt: 2 }}>
+      <Typography variant="h6" gutterBottom>
+        {t('preview.title') || 'PDF Preview'}
+      </Typography>
+      <iframe
+        src={filePath}
+        title="PDF Preview"
+        style={{ width: '100%', height: '600px', border: 'none' }}
+      />
+    </Box>
+  );
+}

--- a/internal/ui/src/components/ReportPanel.jsx
+++ b/internal/ui/src/components/ReportPanel.jsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react";
-import { Box, Typography } from "@mui/material";
+import { Box, Typography, Button } from "@mui/material";
 import { Bar } from "react-chartjs-2";
 import {
   Chart,
@@ -11,13 +11,23 @@ import {
   Legend,
 } from "chart.js";
 import { GenerateStatistics } from "../wailsjs/go/service/DataService";
+import { GenerateDetailedReport } from "../wailsjs/go/pdf/Generator";
 import { useTranslation } from "react-i18next";
 
 Chart.register(CategoryScale, LinearScale, BarElement, Title, Tooltip, Legend);
 
-export default function ReportPanel({ projectId }) {
+export default function ReportPanel({ projectId, onGenerated }) {
   const [stats, setStats] = useState(null);
   const { t } = useTranslation();
+
+  const handleGenerate = async () => {
+    try {
+      const p = await GenerateDetailedReport(projectId);
+      onGenerated && onGenerated(p);
+    } catch (err) {
+      console.error(err);
+    }
+  };
 
   useEffect(() => {
     const load = async () => {
@@ -56,6 +66,9 @@ export default function ReportPanel({ projectId }) {
 
   return (
     <Box>
+      <Button variant="contained" sx={{ mb: 2 }} onClick={handleGenerate}>
+        {t('form.detailedReport')}
+      </Button>
       <Bar data={data} />
       <Typography sx={{ mt: 2 }}>
         {t("reports.trend", { value: stats.trend.toFixed(2) })}

--- a/internal/ui/src/locales/de.json
+++ b/internal/ui/src/locales/de.json
@@ -102,7 +102,11 @@
     "avgExpense": "Ø Ausgaben",
     "median": "Median",
     "stdDev": "Standardabweichung",
-    "trend": "Trend: {{value}}"
+  "trend": "Trend: {{value}}"
+  },
+  "preview": {
+    "title": "PDF Vorschau",
+    "none": "Noch kein PDF erzeugt"
   },
   "language": "Sprache",
   "language_de": "Deutsch",

--- a/internal/ui/src/locales/en.json
+++ b/internal/ui/src/locales/en.json
@@ -104,6 +104,10 @@
     "stdDev": "Std Dev",
     "trend": "Trend: {{value}}"
   },
+  "preview": {
+    "title": "PDF Preview",
+    "none": "No PDF generated"
+  },
   "language": "Language",
   "language_de": "German",
   "language_en": "English",


### PR DESCRIPTION
## Summary
- add `PDFPreview` React component to show last generated PDF via `<iframe>`
- wire up preview in `FormsPanel` and `ReportPanel`
- expose preview panel in `App.jsx`
- localize preview messages
- update end-to-end test to check for preview visibility

## Testing
- `make vet`
- `make go-test`
- `npm run lint --prefix internal/ui`
- `npm test --prefix internal/ui`
- `npm run test:e2e --prefix internal/ui` *(fails: Playwright browsers missing)*

------
https://chatgpt.com/codex/tasks/task_e_686a66d82fd08333a8f00e9255c5b95f