### PR TITLE
Add CLI CSV export and improve ExportProjectCSV

### DIFF
--- a/docs/DOCUMENTATION.md
+++ b/docs/DOCUMENTATION.md
@@ -153,7 +153,8 @@ The application starts in German. Use the dropdown in the top toolbar to switch 
 - **Member Tracking**: Manage club members with names, emails and join dates.
 - **Unit Tests**: Tests covering the tax calculation logic.
 - **Backup & Restore**: The `DataService` can export and restore the SQLite database for easy backups. Use `-exportdb <file>` to dump the database or `-restoredb <file>` to load it before the UI starts.
-- **CSV Export**: Use the `ExportProjectCSV` method to save all incomes and expenses of a project to a CSV file.
+- **CSV Export**: Use the `ExportProjectCSV` method or pass `-exportcsv <projectID>:<file>` when starting the application to save all incomes and expenses of a project. Example:
+`./baristeuer -exportcsv 1:report.csv`
 - **Docker-Unterstützung**: Ein `Dockerfile` ermöglicht den containerisierten Build des Projekts.
 
 ## Optional Plugins


### PR DESCRIPTION
## Summary
- add `-exportcsv` CLI flag for exporting a project's incomes and expenses directly to CSV
- reopen the database in `ExportProjectCSV` when it's closed
- cover reopened export in tests
- document the new flag with example usage

## Testing
- `go test ./cmd/... ./internal/... ./internal/pdf/...`

------
https://chatgpt.com/codex/tasks/task_e_686a66d93f4c8333a6a372dd9fe7a84e