### PR TITLE
Improve PDF preview

### DIFF
--- a/internal/ui/src/components/PDFPreview.jsx
+++ b/internal/ui/src/components/PDFPreview.jsx
@@ -1,20 +1,51 @@
-import { Box, Typography } from "@mui/material";
+import { Box, Typography, Alert, Button } from "@mui/material";
 import { useTranslation } from "react-i18next";
+import { useState, useEffect } from "react";
 
 export default function PDFPreview({ filePath }) {
   const { t } = useTranslation();
+  const [loadError, setLoadError] = useState(false);
+
+  useEffect(() => {
+    setLoadError(false);
+  }, [filePath]);
+
   if (!filePath) {
     return <Typography>{t('preview.none') || 'No PDF generated yet'}</Typography>;
   }
+
   return (
     <Box sx={{ mt: 2 }}>
       <Typography variant="h6" gutterBottom>
         {t('preview.title') || 'PDF Preview'}
       </Typography>
+      {loadError && (
+        <Alert severity="error" sx={{ mb: 2 }}>
+          {t('preview.error') || 'Unable to load PDF'}
+        </Alert>
+      )}
+      <Box sx={{ mb: 1 }}>
+        <Button
+          variant="outlined"
+          onClick={() => window.open(filePath, '_blank')}
+        >
+          {t('preview.open') || 'Open'}
+        </Button>
+        <Button
+          variant="outlined"
+          sx={{ ml: 1 }}
+          component="a"
+          href={filePath}
+          download
+        >
+          {t('preview.download') || 'Download'}
+        </Button>
+      </Box>
       <iframe
         src={filePath}
         title="PDF Preview"
         style={{ width: '100%', height: '600px', border: 'none' }}
+        onError={() => setLoadError(true)}
       />
     </Box>
   );

--- a/internal/ui/src/locales/de.json
+++ b/internal/ui/src/locales/de.json
@@ -104,10 +104,13 @@
     "stdDev": "Standardabweichung",
   "trend": "Trend: {{value}}"
   },
-  "preview": {
-    "title": "PDF Vorschau",
-    "none": "Noch kein PDF erzeugt"
-  },
+    "preview": {
+      "title": "PDF Vorschau",
+      "none": "Noch kein PDF erzeugt",
+      "error": "PDF konnte nicht geladen werden",
+      "open": "Im neuen Fenster öffnen",
+      "download": "Herunterladen"
+    },
   "language": "Sprache",
   "language_de": "Deutsch",
   "language_en": "Englisch",

--- a/internal/ui/src/locales/en.json
+++ b/internal/ui/src/locales/en.json
@@ -104,10 +104,13 @@
     "stdDev": "Std Dev",
     "trend": "Trend: {{value}}"
   },
-  "preview": {
-    "title": "PDF Preview",
-    "none": "No PDF generated"
-  },
+    "preview": {
+      "title": "PDF Preview",
+      "none": "No PDF generated",
+      "error": "Failed to load PDF",
+      "open": "Open",
+      "download": "Download"
+    },
   "language": "Language",
   "language_de": "German",
   "language_en": "English",


### PR DESCRIPTION
## Summary
- show PDF load error in `PDFPreview`
- add open and download buttons
- provide translations for new messages

## Testing
- `npm run lint --prefix internal/ui`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_686ab06be2d883339e68ddc924214fdc