### PR TITLE
Add tests for PDF generation flow

### DIFF
--- a/internal/ui/e2e/simple.spec.js
+++ b/internal/ui/e2e/simple.spec.js
@@ -1,5 +1,13 @@
 import { test, expect } from '@playwright/test'
 
+test.beforeEach(async ({ page }) => {
+  await page.addInitScript(() => {
+    window.backend = {
+      Generator: { GenerateReport: async () => 'test.pdf' },
+    }
+  })
+})
+
 test('basic interactions', async ({ page }) => {
   await page.goto('/')
 
@@ -17,5 +25,8 @@ test('basic interactions', async ({ page }) => {
 
   // open PDF preview
   await page.getByRole('button', { name: 'PDF Vorschau' }).click()
-  await expect(page.getByTitle('PDF Preview')).toBeVisible()
+  await expect(page.getByRole('button', { name: 'PDF erzeugen' })).toBeVisible()
+
+  await page.getByRole('button', { name: 'PDF erzeugen' }).click()
+  await expect(page.getByText('Download')).toBeVisible()
 })

--- a/internal/ui/src/App.test.js
+++ b/internal/ui/src/App.test.js
@@ -1,7 +1,35 @@
 import { render, fireEvent } from '@testing-library/svelte'
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
 import '@testing-library/jest-dom'
 import App from './App.svelte'
+
+vi.mock('./wailsjs/go/service/DataService', () => {
+  const incomes = []
+  const expenses = []
+  return {
+    Backend: {
+      CreateProject: vi.fn().mockResolvedValue({ id: 1 }),
+      ListIncomes: vi.fn(() => Promise.resolve(incomes)),
+      ListExpenses: vi.fn(() => Promise.resolve(expenses)),
+      AddIncome: vi.fn((_p, source, amount) => {
+        incomes.push({ source, amount })
+        return Promise.resolve()
+      }),
+      AddExpense: vi.fn((_p, desc, amount) => {
+        expenses.push({ desc, amount })
+        return Promise.resolve()
+      }),
+    },
+    Generator: {
+      GenerateReport: vi.fn().mockResolvedValue('test.pdf'),
+    },
+  }
+})
+
+beforeEach(() => {
+  window.backend = { Generator: { GenerateReport: vi.fn().mockResolvedValue('test.pdf') } }
+  window.open = vi.fn()
+})
 
 describe('App component', () => {
   it('allows basic interactions', async () => {
@@ -11,16 +39,40 @@ describe('App component', () => {
     await fireEvent.input(getByPlaceholderText('Quelle'), { target: { value: 'Job' } })
     await fireEvent.input(getAllByPlaceholderText('Betrag')[0], { target: { value: '100' } })
     await fireEvent.click(getAllByText('Hinzufügen')[0])
+    await Promise.resolve()
     expect(getByText('Job')).toBeInTheDocument()
 
     // expense
     await fireEvent.input(getByPlaceholderText('Beschreibung'), { target: { value: 'Food' } })
     await fireEvent.input(getAllByPlaceholderText('Betrag')[1], { target: { value: '50' } })
     await fireEvent.click(getAllByText('Hinzufügen')[1])
+    await Promise.resolve()
     expect(getByText('Food')).toBeInTheDocument()
 
     // PDF preview toggle
     await fireEvent.click(getByText('PDF Vorschau'))
-    expect(getByTitle('PDF Preview')).toBeInTheDocument()
+    expect(getByText('PDF erzeugen')).toBeInTheDocument()
+  })
+
+  it('generates a PDF and shows download link', async () => {
+    const { getByText, getByTitle, findByText } = render(App)
+
+    await fireEvent.click(getByText('PDF Vorschau'))
+    await fireEvent.click(getByText('PDF erzeugen'))
+
+    await findByText('Download')
+    const link = getByText('Download')
+    expect(link).toHaveAttribute('href', expect.stringContaining('file://test.pdf'))
+  })
+
+  it('shows an error when PDF generation fails', async () => {
+    const errorMessage = 'boom'
+    window.backend.Generator.GenerateReport = vi.fn().mockRejectedValue(new Error(errorMessage))
+
+    const { getByText, findByText } = render(App)
+    await fireEvent.click(getByText('PDF Vorschau'))
+    await fireEvent.click(getByText('PDF erzeugen'))
+
+    expect(await findByText(errorMessage)).toBeInTheDocument()
   })
 })

--- a/internal/ui/src/wailsjs/go/service/DataService/index.js
+++ b/internal/ui/src/wailsjs/go/service/DataService/index.js
@@ -1,0 +1,20 @@
+let incomes = []
+let expenses = []
+
+export const Backend = {
+  async CreateProject() { return { id: 1 } },
+  async ListIncomes() { return incomes },
+  async ListExpenses() { return expenses },
+  async AddIncome(_projectId, source, amount) {
+    incomes.push({ source, amount })
+  },
+  async AddExpense(_projectId, desc, amount) {
+    expenses.push({ desc, amount })
+  },
+};
+export const Generator = {
+  async GenerateReport() { return 'test.pdf'; }
+};
+if (typeof window !== 'undefined') {
+  window.backend = { Generator };
+}


### PR DESCRIPTION
## Summary
- mock Wails bindings with a simple in-memory implementation
- extend component tests to cover PDF creation success and error cases
- update Playwright e2e test for PDF generation
- add stub `wailsjs` module for tests

## Testing
- `npm test --prefix internal/ui`
- `npm run test:e2e --prefix internal/ui`


------
https://chatgpt.com/codex/tasks/task_e_686bab2046408333a85f1462d810598d