### PR TITLE
Clarify frontend test requirements

### DIFF
--- a/docs/DOCUMENTATION.md
+++ b/docs/DOCUMENTATION.md
@@ -120,6 +120,9 @@ To run the Svelte unit tests you must install dependencies first:
 npm ci --prefix internal/ui
 npm test --prefix internal/ui
 ```
+The `npm` command and the Playwright browsers must be available in your
+environment. The Makefile target `make ui-test` also expects these
+dependencies to be installed.
 
 ## Configuration
 


### PR DESCRIPTION
## Summary
- explain that Playwright browsers and npm must be installed for the UI tests
- mention that `make ui-test` relies on these dependencies

## Testing
- `make vet`
- `npm ci --prefix internal/ui`
- `PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1 npx -y playwright install`
- `make test` *(fails: Backend.ListProjects is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_686c349a4b9c83338550d6e94d78ff3f