### PR TITLE
Remove obsolete dummy test

### DIFF
--- a/internal/ui/src/App.test.js
+++ b/internal/ui/src/App.test.js
@@ -4,11 +4,24 @@ import '@testing-library/jest-dom'
 import App from './App.svelte'
 
 vi.mock('./wailsjs/go/service/DataService', () => {
+  const projects = []
+  let nextProjectId = 1
   const incomes = []
   const expenses = []
+
   return {
     Backend: {
-      CreateProject: vi.fn().mockResolvedValue({ id: 1 }),
+      ListProjects: vi.fn(() => Promise.resolve(projects)),
+      CreateProject: vi.fn(name => {
+        const p = { id: nextProjectId++, name }
+        projects.push(p)
+        return Promise.resolve(p)
+      }),
+      DeleteProject: vi.fn(id => {
+        const idx = projects.findIndex(p => p.id === id)
+        if (idx !== -1) projects.splice(idx, 1)
+        return Promise.resolve()
+      }),
       ListIncomes: vi.fn(() => Promise.resolve(incomes)),
       ListExpenses: vi.fn(() => Promise.resolve(expenses)),
       AddIncome: vi.fn((_p, source, amount) => {

--- a/internal/ui/src/dummy.test.js
+++ b/internal/ui/src/dummy.test.js
@@ -1,5 +1,0 @@
-import { test, expect } from 'vitest'
-
-test('dummy', () => {
-  expect(true).toBe(true)
-})


### PR DESCRIPTION
## Summary
- delete unused `dummy.test.js`
- update `App.test.js` mock to provide `ListProjects` et al.
- verify JS and Go tests succeed

## Testing
- `npm test --prefix internal/ui`
- `go test ./internal/...`


------
https://chatgpt.com/codex/tasks/task_e_686c47e00f5c833381df7aed2ae8cc0d