### PR TITLE
Add dependency management for UI tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: vet go-test lint ui-test test
+.PHONY: vet go-test lint deps ui-test test
 
 vet:
 	go vet ./cmd/... ./internal/... ./internal/pdf/...
@@ -9,7 +9,11 @@ go-test:
 lint:
 	npm run lint --prefix internal/ui
 
+deps:
+	npm install --prefix internal/ui
+
 ui-test:
+	test -d internal/ui/node_modules || npm install --silent --prefix internal/ui
 	npm test --prefix internal/ui
 
 test: go-test ui-test

--- a/README.md
+++ b/README.md
@@ -13,6 +13,11 @@ Bari$teuer is a cross-platform desktop application that assists German non-profi
 - Generates PDF reports and CSV exports
 - Runs on macOS and Windows
 
+## Tests
+
+UI tests require Node.js dependencies located in `internal/ui`. Run `make deps`
+once to install them before executing `make ui-test` or `make test`.
+
 For installation and detailed usage instructions see [docs/DOCUMENTATION.md](docs/DOCUMENTATION.md).
 
 ---


### PR DESCRIPTION
## Summary
- add optional `deps` target for installing UI dependencies
- ensure `ui-test` installs dependencies if needed
- document how to install UI dependencies

## Testing
- `make vet`
- `make test` *(fails: 7 errors in Vitest UI tests)*

------
https://chatgpt.com/codex/tasks/task_e_686c47e08b2883338d551779cd063c94