### PR TITLE
Update docs with instructions on official forms

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ UI tests require Node.js dependencies located in `internal/ui`. Run `make deps`
 once to install them before executing `make ui-test` or `make test`.
 
 For installation and detailed usage instructions see [docs/DOCUMENTATION.md](docs/DOCUMENTATION.md).
+Place the official PDF forms in `internal/pdf/templates/` as described in [docs/Todo-fuer-User.md](docs/Todo-fuer-User.md).
 
 ---
 

--- a/docs/DOCUMENTATION.md
+++ b/docs/DOCUMENTATION.md
@@ -233,7 +233,7 @@ The Baristeuer application is stable and covers the core features. The backend, 
 
 ### Production Readiness
 
-Offizielle Layouts und umfangreichere PDF-Berichte sind noch in Arbeit. Die CI/CD-Pipeline führt Tests aus, und der aktuelle Funktionsumfang gilt als produktionsreif.
+Die amtlichen Formularlayouts dürfen aus Lizenzgründen nicht im Repository liegen. Laden Sie die Vorlagen selbst herunter und speichern Sie sie im Ordner `internal/pdf/templates/` (siehe [docs/Todo-fuer-User.md](Todo-fuer-User.md)). Die CI/CD-Pipeline führt Tests aus und der aktuelle Funktionsumfang gilt als produktionsreif.
 
 ### Potential Next Steps
 


### PR DESCRIPTION
## Summary
- clarify that the official PDF templates have to be provided by users
- reference Todo-fuer-User in docs
- mention template location in README

## Testing
- `go work sync`
- `make vet`
- `make go-test`


------
https://chatgpt.com/codex/tasks/task_e_686c5a0054d8833396c734f66a466254