### PR TITLE
Update UI package metadata

### DIFF
--- a/internal/ui/package-lock.json
+++ b/internal/ui/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "vite-svelte-starter",
-  "version": "0.0.0",
+  "name": "baristeuer-ui",
+  "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "vite-svelte-starter",
-      "version": "0.0.0",
+      "name": "baristeuer-ui",
+      "version": "1.0.0",
       "devDependencies": {
         "@playwright/test": "^1.53.2",
         "@sveltejs/vite-plugin-svelte": "^5.1.0",

--- a/internal/ui/package.json
+++ b/internal/ui/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "vite-svelte-starter",
+  "name": "baristeuer-ui",
   "private": true,
-  "version": "0.0.0",
+  "version": "1.0.0",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## Summary
- rename `vite-svelte-starter` package to `baristeuer-ui`
- set UI package version to `1.0.0`

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_686c5a00d5a48333a65a7c1044698d2c