### PR TITLE
Rename expense description to category

### DIFF
--- a/internal/ui/src/App.svelte
+++ b/internal/ui/src/App.svelte
@@ -8,7 +8,7 @@
   let incomeSource = '';
   let incomeAmount = '';
   let expenses = [];
-  let expenseDesc = '';
+  let expenseCategory = '';
   let expenseAmount = '';
   let showPDF = false;
   let pdfPath = '';
@@ -55,10 +55,10 @@
   }
 
   async function addExpense() {
-    if (!expenseDesc || !expenseAmount) return;
-    await Backend.AddExpense(projectId, expenseDesc, parseFloat(expenseAmount));
+    if (!expenseCategory || !expenseAmount) return;
+    await Backend.AddExpense(projectId, expenseCategory, parseFloat(expenseAmount));
     expenses = await Backend.ListExpenses(projectId);
-    expenseDesc = '';
+    expenseCategory = '';
     expenseAmount = '';
   }
 </script>
@@ -97,15 +97,15 @@
     <div>
       <h2 class="font-semibold mb-2">Ausgaben</h2>
       <div class="flex gap-2 mb-2">
-        <input class="input input-bordered flex-1" placeholder="Beschreibung" bind:value={expenseDesc} />
+        <input class="input input-bordered flex-1" placeholder="Kategorie" bind:value={expenseCategory} />
         <input class="input input-bordered w-24" type="number" placeholder="Betrag" bind:value={expenseAmount} />
         <button class="btn btn-primary" on:click={addExpense}>Hinzufügen</button>
       </div>
       <table class="table w-full">
-        <thead><tr><th>Beschreibung</th><th>Betrag</th></tr></thead>
+        <thead><tr><th>Kategorie</th><th>Betrag</th></tr></thead>
         <tbody>
           {#each expenses as ex}
-          <tr><td>{ex.desc}</td><td>{ex.amount.toFixed(2)}</td></tr>
+          <tr><td>{ex.category}</td><td>{ex.amount.toFixed(2)}</td></tr>
           {/each}
         </tbody>
       </table>

--- a/internal/ui/src/App.test.js
+++ b/internal/ui/src/App.test.js
@@ -28,9 +28,9 @@ vi.mock('./wailsjs/go/service/DataService', () => {
         incomes.push({ source, amount })
         return Promise.resolve()
       }),
-      AddExpense: vi.fn((_p, desc, amount) => {
-        expenses.push({ desc, amount })
-        return Promise.resolve()
+      AddExpense: vi.fn((_p, category, amount) => {
+        expenses.push({ category, amount })
+      return Promise.resolve()
       }),
     },
     Generator: {
@@ -60,7 +60,7 @@ describe('App component', () => {
     expect(getByText('Job')).toBeInTheDocument()
 
     // expense
-    await fireEvent.input(getByPlaceholderText('Beschreibung'), { target: { value: 'Food' } })
+    await fireEvent.input(getByPlaceholderText('Kategorie'), { target: { value: 'Food' } })
     await fireEvent.input(getAllByPlaceholderText('Betrag')[1], { target: { value: '50' } })
     await fireEvent.click(getAllByText('Hinzufügen')[1])
     await Promise.resolve()

--- a/internal/ui/src/wailsjs/go/service/DataService.js
+++ b/internal/ui/src/wailsjs/go/service/DataService.js
@@ -32,8 +32,8 @@ export const Backend = {
   async ListIncomes(projectId) {
     return incomes.filter(i => i.projectId === projectId);
   },
-  async AddExpense(projectId, desc, amount) {
-    const rec = { id: nextExpenseId++, projectId, desc, amount: parseFloat(amount) };
+  async AddExpense(projectId, category, amount) {
+    const rec = { id: nextExpenseId++, projectId, category, amount: parseFloat(amount) };
     expenses.push(rec);
     return rec;
   },

--- a/internal/ui/src/wailsjs/go/service/DataService/index.js
+++ b/internal/ui/src/wailsjs/go/service/DataService/index.js
@@ -8,8 +8,8 @@ export const Backend = {
   async AddIncome(_projectId, source, amount) {
     incomes.push({ source, amount })
   },
-  async AddExpense(_projectId, desc, amount) {
-    expenses.push({ desc, amount })
+  async AddExpense(_projectId, category, amount) {
+    expenses.push({ category, amount })
   },
 };
 export const Generator = {


### PR DESCRIPTION
## Summary
- rename `expenseDesc` to `expenseCategory` in App
- track expense category in DataService modules
- adjust tests for new field

## Testing
- `npm test` in `internal/ui`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_686cc8858558833387c327de6d6ec061