### PR TITLE
Switch install commands to npm ci

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,10 +10,10 @@ lint:
 	npm run lint --prefix internal/ui
 
 deps:
-	npm install --prefix internal/ui
+	npm ci --prefix internal/ui
 
 ui-test:
-	test -d internal/ui/node_modules || npm install --silent --prefix internal/ui
+	test -d internal/ui/node_modules || npm ci --silent --prefix internal/ui
 	npm test --prefix internal/ui
 
 test: go-test ui-test


### PR DESCRIPTION
## Summary
- use `npm ci` instead of `npm install` in Makefile

## Testing
- `make deps`
- `make ui-test`


------
https://chatgpt.com/codex/tasks/task_e_686cce24d98c8333b97432f4553a0453